### PR TITLE
improve seek performence when seeking a wide range

### DIFF
--- a/src/client/InputStreamImpl.cpp
+++ b/src/client/InputStreamImpl.cpp
@@ -734,7 +734,7 @@ void InputStreamImpl::seekInternal(int64_t pos) {
     }
 
     try {
-        if (blockReader && pos > cursor && pos < endOfCurBlock) {
+        if (blockReader && pos > cursor && pos < endOfCurBlock && (pos - cursor) <= blockReader->available()) {
             blockReader->skip(pos - cursor);
             cursor = pos;
             return;


### PR DESCRIPTION
When seeking to target offset in one hdfs block, it will read all data between current offset and target offset.
This is very time consuming when the block size is very large.
For ssb orc 30G test suite on doris, it will improve 2.3x


