### PR TITLE
[chore](workflow) Re-build the third-party libraries automatically when the workflows fail

### DIFF
--- a/.github/workflows/build-1.2.yml
+++ b/.github/workflows/build-1.2.yml
@@ -225,7 +225,7 @@ jobs:
           gh release download "${tag_name}"
 
           content="$(gh release view "${tag_name}" | sed -n '/Update Time:/,/Doris Version:/p')"
-          echo -ne "${content}\nStatus: *SUCCESS*\n\n## Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
+          echo -ne "${content}\nStatus: *SUCCESS*\n\n## SHA256 Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
           gh release edit -F release_note.md "${tag_name}"
 
   failure:
@@ -245,6 +245,5 @@ jobs:
 
           gh release download "${tag_name}"
 
-          content="$(gh release view "${tag_name}"" | sed -n '/Update Time:/,/Doris Version:/p')"
-          echo -ne "${content}\nStatus: *FAILURE*\n\n## Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
+          echo -ne "Status: *FAILURE*\n\n## SHA256 Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
           gh release edit -F release_note.md "${tag_name}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
           gh release download automation
 
           content="$(gh release view automation | sed -n '/Update Time:/,/Doris Version:/p')"
-          echo -ne "${content}\nStatus: *SUCCESS*\n\n## Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
+          echo -ne "${content}\nStatus: *SUCCESS*\n\n## SHA256 Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
           gh release edit -F release_note.md automation
 
   failure:
@@ -229,6 +229,5 @@ jobs:
         run: |
           gh release download automation
 
-          content="$(gh release view automation | sed -n '/Update Time:/,/Doris Version:/p')"
-          echo -ne "${content}\nStatus: *FAILURE*\n\n## Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
+          echo -ne "Status: *FAILURE*\n\n## SHA256 Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
           gh release edit -F release_note.md automation


### PR DESCRIPTION
Currently, if the workflows failed, we should re-trigger the workflows manually. This PR introduces a way to do this work automatically.