### PR TITLE
[chore](workflow) Mark Apache Doris Third Party Prebuilt as a latest release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
 
           content="$(gh release view automation | sed -n '/Update Time:/,/Doris Version:/p')"
           echo -ne "${content}\nStatus: *SUCCESS*\n\n## SHA256 Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
-          gh release edit -F release_note.md automation
+          gh release edit --latest -F release_note.md automation
 
   failure:
     name: Failure
@@ -230,4 +230,4 @@ jobs:
           gh release download automation
 
           echo -ne "Status: *FAILURE*\n\n## SHA256 Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
-          gh release edit -F release_note.md automation
+          gh release edit --latest -F release_note.md automation


### PR DESCRIPTION
Although the release `Apache Doris Third Party Prebuilt` was created months ago, its content is changing all the time.

Because the artifacts are needed by BE UT workflows, we overwrite them in workflow instead of creating a brand new release. As a consequence, the release `Apache Doris Third Party Prebuilt` is considered as a obsolete one.

I think we can always mark it as a latest release because the artifacts are built against the _**master**_ branch of `Apache Doris`. After that, we can access the artifacts more conveniently.