### PR TITLE
[Fix](libhdfs3) Fix AES Block size to 128 bits.

### DIFF
--- a/src/client/CryptoCodec.cpp
+++ b/src/client/CryptoCodec.cpp
@@ -138,8 +138,9 @@ namespace Hdfs {
 		// Calculate new IV when appending an existed file.
 		std::string iv = encryptionInfo->getIv();
 		if (stream_offset > 0) {
-			counter = stream_offset / AlgorithmBlockSize;
-			padding = stream_offset % AlgorithmBlockSize;
+                        // For AES, the algorithm block is fixed size of 128 bits.
+			counter = stream_offset / 16;
+			padding = stream_offset % 16;
 			iv = this->calculateIV(iv, counter);
 		}
 


### PR DESCRIPTION
For AES, the algorithm block is fixed size of 128 bits.
http://en.wikipedia.org/wiki/Advanced_Encryption_Standard

![tsfsMFPoU5](https://user-images.githubusercontent.com/1736049/213705953-63c7e422-a780-413c-8038-2859c430da1f.jpg)