### PR TITLE
[Fix](libhdfs3) Fix seek(0) does not reset stream offset of CryptoCodec.

### DIFF
--- a/src/client/CryptoCodec.cpp
+++ b/src/client/CryptoCodec.cpp
@@ -23,6 +23,8 @@
 #include "CryptoCodec.h"
 #include "Logger.h"
 
+#include <inttypes.h>
+
 using namespace Hdfs::Internal;
 
 
@@ -142,7 +144,14 @@ namespace Hdfs {
 			counter = stream_offset / 16;
 			padding = stream_offset % 16;
 			iv = this->calculateIV(iv, counter);
-		}
+		} else if (stream_offset == 0) {
+                        counter = 0;
+                        padding = 0;
+                } else {
+                        LOG(WARNING, "CryptoCodec : Invalid stream_offset %" PRId64, stream_offset);
+                        return -1;
+                
+                }
 
 		// Judge the crypto method is encrypt or decrypt.
 		int enc = (method == CryptoMethod::ENCRYPT) ? 1 : 0;


### PR DESCRIPTION
### Issue:
e.g. Client called `seek(3)`, then called `seek(0)`。`seek(0)` did not reset stream offset of CryptoCodec, it still use CryptoCodec calculate information when calling `seek(3)`。It caused de/crypto error.

### Solution:
Fix seek(0) does not reset stream offset of CryptoCodec.