### PR TITLE
[chore](github) Use LLVM Clang to build the libraries by default on macOS

### DIFF
--- a/.github/workflows/build-1.2.yml
+++ b/.github/workflows/build-1.2.yml
@@ -123,6 +123,7 @@ jobs:
               'openjdk@11'
               'maven'
               'node'
+              'llvm'
 
           - name: Linux
             os: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,7 @@ jobs:
               'openjdk@11'
               'maven'
               'node'
+              'llvm'
 
           - name: Linux
             os: ubuntu-22.04


### PR DESCRIPTION
In [doris#17292](https://github.com/apache/doris/pull/17292), we use LLVM Clang to build [Apache Doris](https://github.com/apache/doris) by default on macOS. Therefore, we should also use LLVM Clang to build the third-party libraries.