### PR TITLE
[chore] Remove deprecated templates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,185 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Build
+
+on: ['push', 'pull_request']
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      matrix:
+        config:
+          - name: macOS
+            os: macos-12
+            packages: >-
+              'automake'
+              'autoconf'
+              'libtool'
+              'pkg-config'
+              'texinfo'
+              'coreutils'
+              'gnu-getopt'
+              'python@3'
+              'cmake'
+              'ninja'
+              'ccache'
+              'bison'
+              'byacc'
+              'gettext'
+              'wget'
+              'pcre'
+              'openjdk@11'
+              'maven'
+              'node'
+              'llvm@15'
+
+          - name: Linux
+            os: ubuntu-22.04
+            packages: >-
+              'build-essential'
+              'automake'
+              'autoconf'
+              'libtool-bin'
+              'pkg-config'
+              'cmake'
+              'ninja-build'
+              'ccache'
+              'python-is-python3'
+              'bison'
+              'byacc'
+              'flex'
+              'binutils-dev'
+              'libiberty-dev'
+              'curl'
+              'git'
+              'zip'
+              'unzip'
+              'autopoint'
+              'openjdk-11-jdk'
+              'openjdk-11-jdk-headless'
+              'maven'
+
+    runs-on: ${{ matrix.config.os }}
+    steps:
+      - name: Prepare for ${{ matrix.config.os }}
+        run: |
+          cd /tmp
+
+          curl -L https://sourceforge.net/projects/libpng/files/zlib/1.2.11/zlib-1.2.11.tar.gz | tar -zxf -
+          curl -L https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.gz -o - | tar -zxf -
+
+          if [[ "${{ matrix.config.name }}" == 'macOS' ]]; then
+            brew install ${{ matrix.config.packages }}
+
+            CELLARS=(${{ matrix.config.packages }})
+            for cellar in "${CELLARS[@]}"; do
+              EXPORT_CELLARS="$(brew --prefix)/opt/${cellar}/bin:${EXPORT_CELLARS}"
+            done
+            export PATH="${EXPORT_CELLARS}:/usr/bin:${PATH}"
+
+            export CC="$(brew --prefix)/opt/llvm@15/bin/clang"
+            export CXX="$(brew --prefix)/opt/llvm@15/bin/clang++"
+            boost_toolset=clang
+          else
+            sudo apt update
+            sudo DEBIAN_FRONTEND=noninteractive apt install --yes ${{ matrix.config.packages }}
+
+            export DEFAULT_DIR='/opt'
+            export PATH="${DEFAULT_DIR}/ldb-toolchain/bin:${PATH}"
+
+            mkdir -p "${DEFAULT_DIR}"
+
+            wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.12/ldb_toolchain_gen.sh \
+              -q -O /tmp/ldb_toolchain_gen.sh
+            bash /tmp/ldb_toolchain_gen.sh "${DEFAULT_DIR}/ldb-toolchain"
+
+            cxxflags='-static'
+            boost_toolset=gcc
+          fi
+
+          INSTALLED_DIR='/opt/installed'
+
+          # Install zlib
+          pushd zlib-1.2.11
+          CFLAGS="-fPIC" \
+            CPPFLAGS="-I${INSTALLED_DIR}/include" \
+            LDFLAGS="-L${INSTALLED_DIR}/lib" \
+            ./configure --prefix="${INSTALLED_DIR}" --static
+
+          make -j "$(nproc)"
+          sudo make install
+
+          cd contrib/minizip
+          autoreconf --force --install
+          ./configure --prefix="${INSTALLED_DIR}" --enable-static=yes --enable-shared=no
+          make -j "$(nproc)"
+          sudo make install
+          popd
+
+          # Install Boost
+          pushd boost_1_73_0
+          CXXFLAGS="${cxxflags}" ./bootstrap.sh --prefix="${INSTALLED_DIR}" --with-toolset="${boost_toolset}"
+          # -q: Fail at first error
+          sudo ./b2 -q link=static runtime-link=static -j "$(nproc)" --without-mpi --without-graph \
+            --without-graph_parallel --without-python \
+            cxxflags="-std=c++11 -g -I${INSTALLED_DIR}/include -L${INSTALLED_DIR}/lib" install
+          popd
+
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Build
+        run: |
+          if [[ "${{ matrix.config.name }}" == 'macOS' ]]; then
+            CELLARS=(${{ matrix.config.packages }})
+            for cellar in "${CELLARS[@]}"; do
+              EXPORT_CELLARS="$(brew --prefix)/opt/${cellar}/bin:${EXPORT_CELLARS}"
+            done
+            export PATH="${EXPORT_CELLARS}:/usr/bin:${PATH}"
+
+            export CC="$(brew --prefix)/opt/llvm@15/bin/clang"
+            export CXX="$(brew --prefix)/opt/llvm@15/bin/clang++"
+            warning_narrowing='-Wno-c++11-narrowing'
+          else
+            export DEFAULT_DIR='/opt'
+            export PATH="${DEFAULT_DIR}/ldb-toolchain/bin:${PATH}"
+            warning_narrowing='-Wno-narrowing'
+          fi
+
+          INSTALLED_DIR='/opt/installed'
+
+          mkdir build
+          cd build
+          cmake -G Ninja \
+            -DCMAKE_INSTALL_PREFIX="${INSTALLED_DIR}" \
+            -DBUILD_STATIC_LIBRARIES=ON \
+            -DBUILD_SHARED_LIBRARIES=OFF \
+            -DBOOST_ROOT="${INSTALLED_DIR}" \
+            -DZLIB_ROOT="${INSTALLED_DIR}" \
+            -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer ${warning_narrowing}" \
+            -DUSE_STAT64=0 \
+            -DUSE_AVX2="ON" \
+            -DUSE_BTHREAD="OFF" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DBUILD_CONTRIBS_LIB=ON ..
+          ninja -j "$(nproc)"
+          sudo ninja install
+

--- a/src/core/CLucene/index/_Term.h
+++ b/src/core/CLucene/index/_Term.h
@@ -13,7 +13,7 @@
 CL_NS_DEF(index)
 
 
-class Term_Equals:public CL_NS_STD(binary_function)<const Term*,const Term*,bool>
+class Term_Equals
 {
 public:
 	bool operator()( const Term* val1, const Term* val2 ) const{

--- a/src/core/CLucene/search/BooleanQuery.cpp
+++ b/src/core/CLucene/search/BooleanQuery.cpp
@@ -25,7 +25,7 @@ CL_NS_USE(index)
 CL_NS_USE(util)
 CL_NS_DEF(search)
 
-	class BooleanClause_Compare:public CL_NS_STD(binary_function)<const BooleanClause*,const BooleanClause*,bool>
+	class BooleanClause_Compare
 	{
 	public:
 		bool operator()( const BooleanClause* val1, const BooleanClause* val2 ) const {

--- a/src/core/CLucene/search/MultiPhraseQuery.cpp
+++ b/src/core/CLucene/search/MultiPhraseQuery.cpp
@@ -377,7 +377,7 @@ TCHAR* MultiPhraseQuery::toString(const TCHAR* f) const {
 	return buffer.giveBuffer();
 }
 
-class TermArray_Equals:public CL_NS_STD(binary_function)<const Term**,const Term**,bool>
+class TermArray_Equals
 {
 public:
 	bool operator()( CL_NS(util)::ArrayBase<CL_NS(index)::Term*>* val1, CL_NS(util)::ArrayBase<CL_NS(index)::Term*>* val2 ) const{

--- a/src/core/CLucene/util/Equators.h
+++ b/src/core/CLucene/util/Equators.h
@@ -22,19 +22,19 @@ CL_NS_DEF(util)
 /** @internal */
 class CLUCENE_INLINE_EXPORT Equals{
 public:
-	class CLUCENE_INLINE_EXPORT Int32:public CL_NS_STD(binary_function)<const int32_t*,const int32_t*,bool>
+	class CLUCENE_INLINE_EXPORT Int32
 	{
 	public:
 		bool operator()( const int32_t val1, const int32_t val2 ) const;
 	};
 	
-	class CLUCENE_INLINE_EXPORT Char:public CL_NS_STD(binary_function)<const char*,const char*,bool>
+	class CLUCENE_INLINE_EXPORT Char
 	{
 	public:
 		bool operator()( const char* val1, const char* val2 ) const;
 	};
 #ifdef _UCS2
-	class CLUCENE_INLINE_EXPORT WChar: public CL_NS_STD(binary_function)<const wchar_t*,const wchar_t*,bool>
+	class CLUCENE_INLINE_EXPORT WChar
 	{
 	public:
 		bool operator()( const wchar_t* val1, const wchar_t* val2 ) const;
@@ -48,7 +48,7 @@ public:
 
 
     template<typename _cl>
-	class CLUCENE_INLINE_EXPORT Void:public CL_NS_STD(binary_function)<const void*,const void*,bool>
+	class CLUCENE_INLINE_EXPORT Void
 	{
 	public:
 		bool operator()( _cl* val1, _cl* val2 ) const{

--- a/src/core/CLucene/util/_Arrays.h
+++ b/src/core/CLucene/util/_Arrays.h
@@ -124,8 +124,7 @@ CL_NS_DEF(util)
 	
 	template <typename _kt, typename _comparator, 
 		typename class1, typename class2>
-	class CLListEquals:
-		public CL_NS_STD(binary_function)<class1*,class2*,bool>
+	class CLListEquals
 	{
 	typedef typename class1::const_iterator _itr1;
 	typedef typename class2::const_iterator _itr2;

--- a/src/test/index/TestTermVectorsReader.cpp
+++ b/src/test/index/TestTermVectorsReader.cpp
@@ -93,16 +93,14 @@ CL_NS_USE(util);
     }
   };
 
-  struct MyTCharCompare :
-    public std::binary_function<const TCHAR*, const TCHAR*, bool>
+  struct MyTCharCompare
   {
     bool operator () (const TCHAR* v1, const TCHAR* v2) const {
       return _tcscmp(v1, v2) < 0;
     }
   };
 
-  struct TestTokenCompare : 
-    public std::binary_function<const TestToken*, const TestToken*, bool>
+  struct TestTokenCompare
   {
     bool operator () (const TestToken* t1, const TestToken* t2) const {
       return t1->pos < t2->pos;


### PR DESCRIPTION
Changes:
1. `std::binary_function` was marked deprecated in C++ 11 and we should remove it.
2. Add a workflow to validate the build on multiple platforms.