### PR TITLE
[chore](macOS) Specify the version of LLVM for Homebrew to install it

### DIFF
--- a/.github/workflows/build-1.2.yml
+++ b/.github/workflows/build-1.2.yml
@@ -111,7 +111,7 @@ jobs:
               'texinfo'
               'coreutils'
               'gnu-getopt'
-              'python'
+              'python@3'
               'cmake'
               'ninja'
               'ccache'
@@ -123,7 +123,7 @@ jobs:
               'openjdk@11'
               'maven'
               'node'
-              'llvm'
+              'llvm@15'
 
           - name: Linux
             os: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
               'texinfo'
               'coreutils'
               'gnu-getopt'
-              'python'
+              'python@3'
               'cmake'
               'ninja'
               'ccache'
@@ -117,7 +117,7 @@ jobs:
               'openjdk@11'
               'maven'
               'node'
-              'llvm'
+              'llvm@15'
 
           - name: Linux
             os: ubuntu-22.04


### PR DESCRIPTION
Clang 16 was released last week and we haven't ported the codebase to it. If Homebrew bumped the version of LLVM, our workflows would fail.