### PR TITLE
[Fix](chinese analyzer) fix memory leak in chinese analyzer

### DIFF
--- a/src/contribs-lib/CLucene/analysis/LanguageBasedAnalyzer.h
+++ b/src/contribs-lib/CLucene/analysis/LanguageBasedAnalyzer.h
@@ -11,16 +11,18 @@
 
 CL_NS_DEF(analysis)
 
-class CLUCENE_CONTRIBS_EXPORT LanguageBasedAnalyzer: public CL_NS(analysis)::Analyzer{
-	TCHAR lang[100];
-	bool stem;
+class CLUCENE_CONTRIBS_EXPORT LanguageBasedAnalyzer : public CL_NS(analysis)::Analyzer {
+    TCHAR lang[100]{};
+    bool stem;
+
 public:
-	explicit LanguageBasedAnalyzer(const TCHAR* language=nullptr, bool stem=true);
-	~LanguageBasedAnalyzer() override;
-	void setLanguage(const TCHAR* language);
-	void setStem(bool stem);
-    void initDict(const std::string& dictPath);
-	TokenStream* tokenStream(const TCHAR* fieldName, CL_NS(util)::Reader* reader) override;
+    explicit LanguageBasedAnalyzer(const TCHAR *language = nullptr, bool stem = true);
+    ~LanguageBasedAnalyzer() override;
+    void setLanguage(const TCHAR *language);
+    void setStem(bool s);
+    void initDict(const std::string &dictPath);
+    TokenStream *tokenStream(const TCHAR *fieldName, CL_NS(util)::Reader *reader) override;
+    TokenStream *reusableTokenStream(const TCHAR * /*fieldName*/, CL_NS(util)::Reader *reader) override;
 };
 
 CL_NS_END

--- a/src/contribs-lib/CLucene/analysis/jieba/ChineseTokenizer.cpp
+++ b/src/contribs-lib/CLucene/analysis/jieba/ChineseTokenizer.cpp
@@ -3,38 +3,30 @@
 #include "CLucene/util/CLStreams.h"
 #include <memory>
 
-CL_NS_DEF2(analysis,jieba)
+CL_NS_DEF2(analysis, jieba)
 CL_NS_USE(analysis)
 CL_NS_USE(util)
 
-std::unique_ptr<cppjieba::Jieba> ChineseTokenizer::cppjieba = nullptr;
 ChineseTokenizer::ChineseTokenizer(lucene::util::Reader *reader) : Tokenizer(reader) {
     buffer[0] = 0;
 }
 
 void ChineseTokenizer::init(const std::string &dictPath) {
-    if(cppjieba == nullptr) {
-        cppjieba = std::make_unique<cppjieba::Jieba>(
-                dictPath + "/" + "jieba.dict.utf8",
-                dictPath + "/" + "hmm_model.utf8",
-                dictPath + "/" + "user.dict.utf8",
-                dictPath + "/" + "idf.utf8",
-                dictPath + "/" + "stop_words.utf8");
-    }
+    JiebaSingleton::getInstance(dictPath);
 }
 
 CL_NS(analysis)::Token *ChineseTokenizer::next(lucene::analysis::Token *token) {
     // try to read all words
-    if (dataLen == 0) {
+    if (dataLen == 0 || bufferIndex >= dataLen) {
         auto bufferLen = input->read((const void **) &ioBuffer, 1, 0);
         if (bufferLen == -1) {
             dataLen = 0;
+            bufferIndex = 0;
             return NULL;
         }
         char tmp_buffer[4 * bufferLen];
         lucene_wcsntoutf8(tmp_buffer, ioBuffer, bufferLen, 4 * bufferLen);
-        init();
-        cppjieba->Cut(tmp_buffer, tokens_text, true);
+        JiebaSingleton::getInstance().Cut(tmp_buffer, tokens_text, true);
         dataLen = tokens_text.size();
     }
     if (bufferIndex < dataLen) {

--- a/src/contribs-lib/CLucene/analysis/jieba/ChineseTokenizer.h
+++ b/src/contribs-lib/CLucene/analysis/jieba/ChineseTokenizer.h
@@ -10,6 +10,21 @@
 
 CL_NS_DEF2(analysis,jieba)
 
+class JiebaSingleton {
+public:
+    static cppjieba::Jieba& getInstance(const std::string& dictPath = "") {
+        static cppjieba::Jieba instance(dictPath + "/" + "jieba.dict.utf8",
+                                        dictPath + "/" + "hmm_model.utf8",
+                                        dictPath + "/" + "user.dict.utf8",
+                                        dictPath + "/" + "idf.utf8",
+                                        dictPath + "/" + "stop_words.utf8");
+        return instance;
+    }
+
+private:
+    JiebaSingleton() = default;
+};
+
 class ChineseTokenizer : public lucene::analysis::Tokenizer {
 private:
     /** word offset, used to imply which character(in ) is parsed */
@@ -33,19 +48,18 @@ private:
      */
     const TCHAR* ioBuffer{};
     std::vector<std::string> tokens_text;
-    std::vector<std::unique_ptr<Token>> tokens;
+    //std::vector<std::unique_ptr<Token>> tokens;
 
 public:
-    static std::unique_ptr<cppjieba::Jieba> cppjieba;
     // Constructor
     explicit ChineseTokenizer(lucene::util::Reader *reader);
     static void init(const std::string& dictPath="");
 
     // Destructor
-    ~ChineseTokenizer() override {}
+    ~ChineseTokenizer() override = default;
 
     // Override the next method to tokenize Chinese text using Jieba
-    lucene::analysis::Token* next(lucene::analysis::Token* token);
+    lucene::analysis::Token* next(lucene::analysis::Token* token) override;
 };
 
 CL_NS_END2

--- a/src/core/CLucene/search/IndexSearcher.cpp
+++ b/src/core/CLucene/search/IndexSearcher.cpp
@@ -378,8 +378,8 @@ CL_NS_DEF(search)
       Scorer* scorer = NULL;
       try
       {
-        Weight* weight = query->weight(this);
-        Scorer* scorer = weight->scorer(reader);
+        weight = query->weight(this);
+        scorer = weight->scorer(reader);
         if (scorer == NULL) {
           Query* wq = weight->getQuery();
           if (wq != query) // query was rewritten

--- a/src/core/CLucene/search/TermQuery.cpp
+++ b/src/core/CLucene/search/TermQuery.cpp
@@ -147,7 +147,7 @@ CL_NS_DEF(search)
 			return NULL;
 
 		return _CLNEW TermScorer(this, termDocs, similarity,
-								reader->norms(_term->field()));
+								nullptr);
 	}
 
 	Explanation* TermWeight::explain(IndexReader* reader, int32_t doc){

--- a/src/core/CLucene/util/bkd/bkd_writer.cpp
+++ b/src/core/CLucene/util/bkd/bkd_writer.cpp
@@ -53,8 +53,9 @@ namespace bkd {
             bytes_per_doc_ = packed_bytes_length_ + 4 + 4;
         }
 
-        max_points_sort_in_heap_ = (int32_t) (0.5 * (maxMBSortInHeap * 1024 * 1024) / (bytes_per_doc_ * numDataDims));
-
+        // because offline sort is not implemented yet, we just use heap for all points
+        max_points_sort_in_heap_ = totalPointCount;
+        //max_points_sort_in_heap_ = (int32_t) (0.5 * (maxMBSortInHeap * 1024 * 1024) / (bytes_per_doc_ * numDataDims));
         // Finally, we must be able to hold at least the leaf node in heap during build:
         if (max_points_sort_in_heap_ < maxPointsInLeafNode) {
             auto msg = "maxMBSortInHeap=" + std::to_string(maxMBSortInHeap) + " only allows for maxPointsSortInHeap=" + std::to_string(max_points_sort_in_heap_) + ", but this is less than maxPointsInLeafNode=" + std::to_string(maxPointsInLeafNode) + "; either increase maxMBSortInHeap or decrease maxPointsInLeafNode";


### PR DESCRIPTION
1. Failure to implement the reusableTokenStream method results in token stream being created each time, which can cause memory leaks.
2. Refactored the Jieba instance using singleton.
3. Replaced new norm with nullptr in TermScorer to save memory.