### PR TITLE
[chore] Assign names to the build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ on: ['push', 'pull_request']
 
 jobs:
   build:
-    name: Build
     strategy:
       matrix:
         config:
@@ -75,6 +74,7 @@ jobs:
               'openjdk-11-jdk-headless'
               'maven'
 
+    name: Build (${{ matrix.config.name }})
     runs-on: ${{ matrix.config.os }}
     steps:
       - name: Prepare for ${{ matrix.config.os }}


### PR DESCRIPTION
We should mark the build workflow required. Therefore, we should assign names to the build jobs in order to set up the `.asf.yml`.