### PR TITLE
[chore] Porting to GCC 12.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
             brew update
             popd
 
-            brew install ${{ matrix.config.packages }}
+            brew install ${{ matrix.config.packages }} || true
 
             CELLARS=(${{ matrix.config.packages }})
             for cellar in "${CELLARS[@]}"; do

--- a/src/ext/for/bitutil.c
+++ b/src/ext/for/bitutil.c
@@ -122,7 +122,7 @@ uint16_t bitd16(uint16_t *in, unsigned n, uint16_t *px, uint16_t start) {
     vo1 = _mm_or_si128(vo1, v1);
     vx0 = _mm_or_si128(vx0, _mm_xor_si128(v0, vb0));
     vx1 = _mm_or_si128(vx1, _mm_xor_si128(v1, vb0));
-  }                                                                             start = _mm_cvtsi128_si16(_mm_srli_si128(vs,14));
+  }                                                                             start = mm_cvtsi128_si16(_mm_srli_si128(vs,14));
   vo0 = _mm_or_si128(vo0, vo1); o = mm_hor_epi16(vo0);
   vx0 = _mm_or_si128(vx0, vx1); x = mm_hor_epi16(vx0);
     #else
@@ -443,7 +443,7 @@ uint16_t bitz16(uint16_t *in, unsigned n, uint16_t *px, uint16_t start) {
     vo1 = _mm_or_si128(vo1, v1);
     vx0 = _mm_or_si128(vx0, _mm_xor_si128(v0, vb0));
     vx1 = _mm_or_si128(vx1, _mm_xor_si128(v1, vb0));
-  }                                                                                         start = _mm_cvtsi128_si16(_mm_srli_si128(vs,14));
+  }                                                                                         start = mm_cvtsi128_si16(_mm_srli_si128(vs,14));
   vo0 = _mm_or_si128(vo0, vo1); o = mm_hor_epi16(vo0);
   vx0 = _mm_or_si128(vx0, vx1); x = mm_hor_epi16(vx0);
     #else
@@ -488,7 +488,7 @@ uint32_t bitz32(unsigned *in, unsigned n, uint32_t *px, unsigned start) {
     vo1 = _mm_or_si128(vo1, v1);
     vx0 = _mm_or_si128(vx0, _mm_xor_si128(v0, vb0));
     vx1 = _mm_or_si128(vx1, _mm_xor_si128(v1, vb0));
-  }                                                                             start = _mm_cvtsi128_si16(_mm_srli_si128(vs,12));
+  }                                                                             start = mm_cvtsi128_si16(_mm_srli_si128(vs,12));
   vo0 = _mm_or_si128(vo0, vo1); o = mm_hor_epi32(vo0);
   vx0 = _mm_or_si128(vx0, vx1); x = mm_hor_epi32(vx0);
     #else

--- a/src/ext/for/bitutil.h
+++ b/src/ext/for/bitutil.h
@@ -188,8 +188,8 @@ static ALWAYS_INLINE uint64_t mm_hor_epi64( __m128i v) { v = _mm_or_si128( v, _m
 #define ADDI32x4(_v_, _sv_, _vi_) _sv_ = _mm_add_epi32(_mm_add_epi32(_sv_, _vi_),_v_)
 
 //---------------- Convert _mm_cvtsi128_siXX -------------------------------------------
-static ALWAYS_INLINE uint8_t  _mm_cvtsi128_si8 (__m128i v) { return (uint8_t )_mm_cvtsi128_si32(v); }
-static ALWAYS_INLINE uint16_t _mm_cvtsi128_si16(__m128i v) { return (uint16_t)_mm_cvtsi128_si32(v); }
+static ALWAYS_INLINE uint8_t  mm_cvtsi128_si8 (__m128i v) { return (uint8_t )_mm_cvtsi128_si32(v); }
+static ALWAYS_INLINE uint16_t mm_cvtsi128_si16(__m128i v) { return (uint16_t)_mm_cvtsi128_si32(v); }
   #endif
 
 //--------- memset -----------------------------------------


### PR DESCRIPTION
Currently, some errors occur when building clucene by GCC-12.2. This PR fixes these errors.