### PR TITLE
[Fix](c++) Fix row batch not reset notNull data if strip doesn't have PRESENT stream.

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -100,13 +100,16 @@ namespace orc {
           return;
         }
       }
+      rowBatch.hasNulls = false;
     } else if (incomingMask) {
       // If we don't have a notNull stream, copy the incomingMask
       rowBatch.hasNulls = true;
       memcpy(rowBatch.notNull.data(), incomingMask, numValues);
       return;
+    } else {
+      rowBatch.hasNulls = false;
+      memset(rowBatch.notNull.data(), 1, numValues);
     }
-    rowBatch.hasNulls = false;
   }
 
   void ColumnReader::seekToRowGroup(std::unordered_map<uint64_t, PositionProvider>& positions) {


### PR DESCRIPTION
In ORC, PRESENT stream is optional, and ORC Reader reuse `ColumnVectorBatch` to read data. So if it don't reset `notNull `data in `ColumnVectorBatch`, it will use last `notNull` data incorrectly.