### PR TITLE
[Improvement](index compaction) improve index compaction perf by introducing priority queue

### DIFF
--- a/src/core/CLucene/index/SegmentMergeInfo.cpp
+++ b/src/core/CLucene/index/SegmentMergeInfo.cpp
@@ -11,12 +11,11 @@
 
 CL_NS_DEF(index)
 
-SegmentMergeInfo::SegmentMergeInfo(const int32_t b, TermEnum* te, IndexReader* r):
-    docMap(NULL),
-    termEnum(te),
-    base(b),
-    reader(r)
-{
+SegmentMergeInfo::SegmentMergeInfo(const int32_t b, TermEnum *te, IndexReader *r, const int32_t ri) : docMap(NULL),
+                                                                                                      termEnum(te),
+                                                                                                      base(b),
+                                                                                                      reader(r),
+                                                                                                      readerIndex(ri) {
 //Func - Constructor
 //Pre  - b >= 0
 //       te contains a valid reference to a SegmentTermEnum instance

--- a/src/core/CLucene/index/_SegmentMergeInfo.h
+++ b/src/core/CLucene/index/_SegmentMergeInfo.h
@@ -24,9 +24,10 @@ public:
 	Term* term;
 	int32_t base;
 	IndexReader* reader;
+	int32_t readerIndex;
      
 	//Constructor
-	SegmentMergeInfo(const int32_t b, TermEnum* te, IndexReader* r);
+	SegmentMergeInfo(const int32_t b, TermEnum* te, IndexReader* r, int32_t readerIndex=0);
 
 	//Destructor
 	~SegmentMergeInfo();


### PR DESCRIPTION
Description: This pull request addresses the issue of index compaction performance by introducing a priority queue to better manage the process. This update involves changes in IndexWriter.cpp, SegmentMergeInfo.cpp, and _SegmentMergeInfo.h. The key modifications include:

1. Replacing the previous approach for finding the smallest term and constructing a dest_idx_bitmap with a more efficient priority queue based approach.
2. Introducing a new postingQueue class to manage the document merging process.
3. Implementing a new DestDoc struct to store relevant information for each document in the merging process.
4. Refactoring the mergeTerms() method to use the new priority queue based approach.

These changes have resulted in improved performance during the index compaction process, leading to faster indexing and optimized resource usage.