### PR TITLE
[Feature] Implements selection vector for ORC lazy materialization.

### DIFF
--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -186,26 +186,25 @@ namespace orc {
     RowReaderOptions& includeTypes(const std::list<uint64_t>& types);
 
     /**
-      * For files that have structs as the top-level object, filter the fields.
-      * by index. The first field is 0, the second 1, and so on. By default,
-      * all columns are read. This option clears any previous setting of
-      * the selected columns.
-      * @param filterColIndexes a list of fields to read
-      * @return this
-      */
+     * For files that have structs as the top-level object, filter the fields.
+     * by index. The first field is 0, the second 1, and so on. By default,
+     * all columns are read. This option clears any previous setting of
+     * the selected columns.
+     * @param filterColIndexes a list of fields to read
+     * @return this
+     */
     RowReaderOptions& filter(const std::list<uint64_t>& filterColIndexes);
 
     /**
-      * For files that have structs as the top-level object, filter the fields
-      * by name. By default, all columns are read. This option clears
-      * any previous setting of the selected columns.
-      * @param filterColNames a list of fields to read
-      * @return this
-      */
+     * For files that have structs as the top-level object, filter the fields
+     * by name. By default, all columns are read. This option clears
+     * any previous setting of the selected columns.
+     * @param filterColNames a list of fields to read
+     * @return this
+     */
     RowReaderOptions& filter(const std::list<std::string>& filterColNames);
 
-
-      /**
+    /**
      * A map type of <typeId, ReadIntent>.
      */
     typedef std::map<uint64_t, ReadIntent> IdReadIntentMap;
@@ -367,7 +366,8 @@ namespace orc {
   class ORCFilter {
    public:
     virtual ~ORCFilter() = default;
-    virtual void filter(ColumnVectorBatch& data, uint16_t* sel, uint16_t size, void* arg = nullptr) const = 0;
+    virtual void filter(ColumnVectorBatch& data, uint16_t* sel, uint16_t size,
+                        void* arg = nullptr) const = 0;
   };
 
   class RowReader;
@@ -562,7 +562,8 @@ namespace orc {
      * @param options RowReader Options
      * @return a RowReader to read the rows
      */
-    virtual std::unique_ptr<RowReader> createRowReader(const RowReaderOptions& options, const ORCFilter* filter = nullptr) const = 0;
+    virtual std::unique_ptr<RowReader> createRowReader(const RowReaderOptions& options,
+                                                       const ORCFilter* filter = nullptr) const = 0;
 
     /**
      * Get the name of the input stream.

--- a/c++/include/orc/Type.hh
+++ b/c++/include/orc/Type.hh
@@ -27,37 +27,37 @@
 
 namespace orc {
   enum class ReaderCategory {
-      FILTER_CHILD,    // Primitive type that is a filter column
-      FILTER_PARENT,   // Compound type with filter children
-      NON_FILTER       // Non-filter column
+    FILTER_CHILD,   // Primitive type that is a filter column
+    FILTER_PARENT,  // Compound type with filter children
+    NON_FILTER      // Non-filter column
   };
 
   class ReadPhase {
    public:
-      static const int NUM_CATEGORIES = 3;  // Number of values in ReaderCategory
-      std::bitset<NUM_CATEGORIES> categories;
+    static const int NUM_CATEGORIES = 3;  // Number of values in ReaderCategory
+    std::bitset<NUM_CATEGORIES> categories;
 
-      static const ReadPhase ALL;
-      static const ReadPhase LEADERS;
-      static const ReadPhase FOLLOWERS;
-      static const ReadPhase LEADER_PARENTS;
-      static const ReadPhase FOLLOWERS_AND_PARENTS;
+    static const ReadPhase ALL;
+    static const ReadPhase LEADERS;
+    static const ReadPhase FOLLOWERS;
+    static const ReadPhase LEADER_PARENTS;
+    static const ReadPhase FOLLOWERS_AND_PARENTS;
 
-      static ReadPhase fromCategories(const std::unordered_set<ReaderCategory>& cats) {
-        ReadPhase phase;
-        for (ReaderCategory cat : cats) {
-          phase.categories.set(static_cast<size_t>(cat));
-        }
-        return phase;
+    static ReadPhase fromCategories(const std::unordered_set<ReaderCategory>& cats) {
+      ReadPhase phase;
+      for (ReaderCategory cat : cats) {
+        phase.categories.set(static_cast<size_t>(cat));
       }
+      return phase;
+    }
 
-      bool contains(ReaderCategory cat) const {
-        return categories.test(static_cast<size_t>(cat));
-      }
+    bool contains(ReaderCategory cat) const {
+      return categories.test(static_cast<size_t>(cat));
+    }
 
-      bool operator==(const ReadPhase& other) const {
-        return categories == other.categories;
-      }
+    bool operator==(const ReadPhase& other) const {
+      return categories == other.categories;
+    }
   };
 
   enum TypeKind {

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -35,22 +35,23 @@ namespace orc {
   static const uint64_t DIRECTORY_SIZE_GUESS = 16 * 1024;
 
   class ReaderContext {
-  public:
-   ReaderContext() = default;
+   public:
+    ReaderContext() = default;
 
-   const ORCFilter* getFilterCallback() const {
-     return filter;
-   }
+    const ORCFilter* getFilterCallback() const {
+      return filter;
+    }
 
-   ReaderContext& setFilterCallback(std::unordered_set<int> _filterColumnIds, const ORCFilter* _filter) {
-     this->filterColumnIds = std::move(_filterColumnIds);
-     this->filter = _filter;
-     return *this;
-   }
+    ReaderContext& setFilterCallback(std::unordered_set<int> _filterColumnIds,
+                                     const ORCFilter* _filter) {
+      this->filterColumnIds = std::move(_filterColumnIds);
+      this->filter = _filter;
+      return *this;
+    }
 
-  private:
-   std::unordered_set<int> filterColumnIds;
-   const ORCFilter* filter;
+   private:
+    std::unordered_set<int> filterColumnIds;
+    const ORCFilter* filter;
   };
 
   /**
@@ -237,25 +238,26 @@ namespace orc {
      */
     bool hasBadBloomFilters();
 
-
     // build map from type name and id, id to Type
     void buildTypeNameIdMap(Type* type);
 
     std::string toDotColumnPath();
 
-    void nextBatch(ColumnVectorBatch& data, int batchSize, const ReadPhase& readPhase, uint16_t* sel_rowid_idx, void* arg);
+    void nextBatch(ColumnVectorBatch& data, int batchSize, const ReadPhase& readPhase,
+                   uint16_t* sel_rowid_idx, void* arg);
 
     int computeRGIdx(uint64_t rowIndexStride, long rowIdx);
 
     ReadPhase prepareFollowReaders(uint64_t rowIndexStride, long toFollowRow, long fromFollowRow);
 
-  public:
+   public:
     /**
      * Constructor that lets the user specify additional options.
      * @param contents of the file
      * @param options options for reading
      */
-    RowReaderImpl(std::shared_ptr<FileContents> contents, const RowReaderOptions& options, const ORCFilter* filter = nullptr);
+    RowReaderImpl(std::shared_ptr<FileContents> contents, const RowReaderOptions& options,
+                  const ORCFilter* filter = nullptr);
 
     // Select the columns from the options object
     const std::vector<bool> getSelectedColumns() const override;
@@ -357,7 +359,8 @@ namespace orc {
 
     std::unique_ptr<RowReader> createRowReader(const ORCFilter* filter = nullptr) const override;
 
-    std::unique_ptr<RowReader> createRowReader(const RowReaderOptions& options, const ORCFilter* filter = nullptr) const override;
+    std::unique_ptr<RowReader> createRowReader(const RowReaderOptions& options,
+                                               const ORCFilter* filter = nullptr) const override;
 
     uint64_t getContentLength() const override;
     uint64_t getStripeStatisticsLength() const override;

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -25,11 +25,15 @@
 
 namespace orc {
 
-  const ReadPhase ReadPhase::ALL = ReadPhase::fromCategories({ ReaderCategory::FILTER_CHILD, ReaderCategory::FILTER_PARENT, ReaderCategory::NON_FILTER });
-  const ReadPhase ReadPhase::LEADERS = ReadPhase::fromCategories({ ReaderCategory::FILTER_CHILD, ReaderCategory::FILTER_PARENT });
-  const ReadPhase ReadPhase::FOLLOWERS = ReadPhase::fromCategories({ ReaderCategory::NON_FILTER });
-  const ReadPhase ReadPhase::LEADER_PARENTS = ReadPhase::fromCategories({ ReaderCategory::FILTER_PARENT });
-  const ReadPhase ReadPhase::FOLLOWERS_AND_PARENTS = ReadPhase::fromCategories({ ReaderCategory::FILTER_PARENT, ReaderCategory::NON_FILTER });
+  const ReadPhase ReadPhase::ALL = ReadPhase::fromCategories(
+      {ReaderCategory::FILTER_CHILD, ReaderCategory::FILTER_PARENT, ReaderCategory::NON_FILTER});
+  const ReadPhase ReadPhase::LEADERS =
+      ReadPhase::fromCategories({ReaderCategory::FILTER_CHILD, ReaderCategory::FILTER_PARENT});
+  const ReadPhase ReadPhase::FOLLOWERS = ReadPhase::fromCategories({ReaderCategory::NON_FILTER});
+  const ReadPhase ReadPhase::LEADER_PARENTS =
+      ReadPhase::fromCategories({ReaderCategory::FILTER_PARENT});
+  const ReadPhase ReadPhase::FOLLOWERS_AND_PARENTS =
+      ReadPhase::fromCategories({ReaderCategory::FILTER_PARENT, ReaderCategory::NON_FILTER});
 
   Type::~Type() {
     // PASS


### PR DESCRIPTION
1. Implements selection vector for ORC lazy materialization. From the test, currently implements float/double, date/timestamp, decimal, string dict types for better performance, and other types have performance penalty.
2. Decrease `loadStripIndex()` call count.
3. Adjust code format.