### PR TITLE
Revert "[chore](workflow) Upgrade the toolchains to build libraries"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
               'openjdk@11'
               'maven'
               'node'
-              'llvm@16'
+              'llvm@15'
 
           - name: Linux
             os: ubuntu-22.04
@@ -174,7 +174,7 @@ jobs:
             sudo DEBIAN_FRONTEND=noninteractive apt install --yes ${{ matrix.config.packages }}
 
             mkdir -p "${DEFAULT_DIR}"
-            wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.17/ldb_toolchain_gen.sh \
+            wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.12/ldb_toolchain_gen.sh \
               -q -O /tmp/ldb_toolchain_gen.sh
             bash /tmp/ldb_toolchain_gen.sh "${DEFAULT_DIR}/ldb-toolchain"
           fi


### PR DESCRIPTION
Reverts apache/doris-thirdparty#64

Using Clang-16 to build BRPC makes BE UT fail.

```shell
[----------] 5 tests from VOlapTableSinkTest
[ RUN      ] VOlapTableSinkTest.normal
F0512 23:24:07.957393 1902325760 task_group.cpp:629] bthread=4294969088 sched_to itself!
*** Check failure stack trace: ***
./run-be-ut.sh: line 296: 70405 Abort trap: 6           "${test}" --gtest_output="xml:${GTEST_OUTPUT_DIR}/${file_name}.xml" --gtest_print_time=true "${FILTER}"
```
