### PR TITLE
[Update] do not read segment_N file when create new dir, because doris would never read an old index dir

### DIFF
--- a/src/core/CLucene/index/IndexWriter.cpp
+++ b/src/core/CLucene/index/IndexWriter.cpp
@@ -261,13 +261,14 @@ void IndexWriter::init(Directory *d, Analyzer *a, const bool create, const bool 
             // against an index that's currently open for
             // searching.  In this case we write the next
             // segments_N file with no segments:
-            try {
+            //NOTE: do not read when create, because doris would never read an old index dir
+            /*try {
                 segmentInfos->read(directory);
                 segmentInfos->clear();
             } catch (CLuceneError &e) {
                 if (e.number() != CL_ERR_IO) throw e;
                 // Likely this means it's a fresh directory
-            }
+            }*/
             segmentInfos->write(directory);
         } else {
             segmentInfos->read(directory);

--- a/src/core/CLucene/index/SDocumentWriter.h
+++ b/src/core/CLucene/index/SDocumentWriter.h
@@ -735,7 +735,7 @@ public:
     void abort(AbortException *ae) override {}
     void setMaxBufferedDocs(int32_t count) override {}
     void setInfoStream(std::ostream *is) override {
-        this->infoStream = infoStream;
+        this->infoStream = is;
     }
     void setRAMBufferSizeMB(float_t mb) override {
         if ((int32_t) mb == -1) {


### PR DESCRIPTION
fix useless warning message like "W0428 19:29:20.875416 3762117 file_system.cpp:33] [IO_ERROR]failed to get file size /mnt/mdd05/doris.SSD/VEC_ASAN/data/42/182063/1900459902/02000000000013160d42f54a4220048230197aff6f066487_9-26_182004/segments.gen: (2), No such file or directory"