### PR TITLE
[build] change jdk11 to jdk8

### DIFF
--- a/.github/workflows/build-1.2.yml
+++ b/.github/workflows/build-1.2.yml
@@ -120,7 +120,7 @@ jobs:
               'gettext'
               'wget'
               'pcre'
-              'openjdk@8'
+              'openjdk@11'
               'maven'
               'node'
               'llvm@15'

--- a/.github/workflows/build-1.2.yml
+++ b/.github/workflows/build-1.2.yml
@@ -120,7 +120,7 @@ jobs:
               'gettext'
               'wget'
               'pcre'
-              'openjdk@11'
+              'openjdk@8'
               'maven'
               'node'
               'llvm@15'
@@ -147,8 +147,8 @@ jobs:
               'zip'
               'unzip'
               'autopoint'
-              'openjdk-11-jdk'
-              'openjdk-11-jdk-headless'
+              'openjdk-8-jdk'
+              'openjdk-8-jdk-headless'
               'maven'
 
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
               'gettext'
               'wget'
               'pcre'
-              'openjdk@8'
+              'openjdk@11'
               'maven'
               'node'
               'llvm@15'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
               'gettext'
               'wget'
               'pcre'
-              'openjdk@11'
+              'openjdk@8'
               'maven'
               'node'
               'llvm@15'
@@ -141,8 +141,8 @@ jobs:
               'zip'
               'unzip'
               'autopoint'
-              'openjdk-11-jdk'
-              'openjdk-11-jdk-headless'
+              'openjdk-8-jdk'
+              'openjdk-8-jdk-headless'
               'maven'
 
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
After introducing hadoop in thirdparty, we need to use jdk8 to compile it.
If using jdk11 and run BE using jdk8, it will return error: 

`NoSuchMethodError: java.nio.ByteBuffer.position(I)Ljava/nio/ByteBuffer;`