### PR TITLE
[fix](index compaction)ignore doc which dose not exist in destination segment

### DIFF
--- a/src/core/CLucene/index/IndexWriter.cpp
+++ b/src/core/CLucene/index/IndexWriter.cpp
@@ -1684,7 +1684,11 @@ void IndexWriter::mergeTerms(bool hasProx) {
                 auto destDocId = destDoc->destDocId;
                 auto destFreq = destDoc->destFreq;
                 auto& descPositions = destDoc->destPositions;
-
+                // <UINT32_MAX, UINT32_MAX> indicates current row not exist in Doris dest segment.
+                // So we ignore this doc here.
+                if (destIdx == UINT32_MAX || destDocId == UINT32_MAX) {
+                    continue;
+                }
                 auto freqOut = freqOutputList[destIdx];         
                 auto proxOut = proxOutputList[destIdx];
                 auto& docDeltaBuffer = docDeltaBuffers[destIdx];


### PR DESCRIPTION
Doris compaction translation vec:
```cpp
trans_vec
<<dest_idx_num, dest_docId>>
the first level vector: index indicates src segment.
the second level vector: index indicates row id of source segment,
value indicates row id of destination segment.
<UINT32_MAX, UINT32_MAX> indicates current row not exist.
```
When `dest_idx_num` and `desc_docId` is `UINT32_MAX`, it indicates that the current row not exists. 
 So we cannot add this doc to the inverted index either.