### PR TITLE
[fix](compile)Fix compile error in MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ OPTION(BUILD_CONTRIBS
   OFF)
 OPTION(BUILD_CONTRIBS_LIB
   "create targets for building the clucene-contribs-lib"
-  OFF)
+  ON)
 SET(LUCENE_SYS_INCLUDES "" CACHE PATH
       "location for non-system independent files. defaults to CMAKE_INSTALL_PREFIX. see INSTALL documentation for further information."
       )

--- a/src/core/CLucene/util/stringUtil.h
+++ b/src/core/CLucene/util/stringUtil.h
@@ -206,6 +206,8 @@ public:
         return compareSSE2(p1 + size - 16, p2 + size - 16);
     }
 
+#endif
+
     // Compare two strings using sse4.2 intrinsics if they are available. This code assumes
     // that the trivial cases are already handled (i.e. one string is empty).
     // Returns:
@@ -223,7 +225,7 @@ public:
             __m128i xmm0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s1));
             __m128i xmm1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(s2));
             int chars_match = _mm_cmpestri(xmm0, sse_util::CHARS_PER_128_BIT_REGISTER, xmm1,
-                                        sse_util::CHARS_PER_128_BIT_REGISTER, sse_util::STRCMP_MODE);
+                                           sse_util::CHARS_PER_128_BIT_REGISTER, sse_util::STRCMP_MODE);
             if (chars_match != sse_util::CHARS_PER_128_BIT_REGISTER) {
                 return (unsigned char)s1[chars_match] - (unsigned char)s2[chars_match];
             }
@@ -243,8 +245,6 @@ public:
 
         return n1 - n2;
     }
-
-#endif
 
     static inline int32_t utf8_byte_count(uint8_t c) {
         static constexpr int32_t LUT[256] = {


### PR DESCRIPTION
Turn on `BUILD_CONTRIBS_LIB` by default.