### PR TITLE
[fix](build)update available boost download url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           cd /tmp
 
           curl -L https://sourceforge.net/projects/libpng/files/zlib/1.2.11/zlib-1.2.11.tar.gz | tar -zxf -
-          curl -L https://github.com/boostorg/boost/releases/download/boost-1.81.0/boost-1.81.0.tar.gz -o - | tar -zxf -
+          curl -L https://archives.boost.io/release/1.81.0/source/boost_1_81_0.tar.gz -o - | tar -zxf -
 
           if [[ "${{ matrix.config.name }}" == 'macOS' ]]; then
             pushd "$(brew --repo)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           cd /tmp
 
           curl -L https://sourceforge.net/projects/libpng/files/zlib/1.2.11/zlib-1.2.11.tar.gz | tar -zxf -
-          curl -L https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.gz -o - | tar -zxf -
+          curl -L https://phoenixnap.dl.sourceforge.net/project/boost/boost/1.81.0/boost_1_81_0.tar.gz -o - | tar -zxf -
 
           if [[ "${{ matrix.config.name }}" == 'macOS' ]]; then
             pushd "$(brew --repo)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           cd /tmp
 
           curl -L https://sourceforge.net/projects/libpng/files/zlib/1.2.11/zlib-1.2.11.tar.gz | tar -zxf -
-          curl -L https://phoenixnap.dl.sourceforge.net/project/boost/boost/1.81.0/boost_1_81_0.tar.gz -o - | tar -zxf -
+          curl -L https://github.com/boostorg/boost/releases/download/boost-1.81.0/boost-1.81.0.tar.gz -o - | tar -zxf -
 
           if [[ "${{ matrix.config.name }}" == 'macOS' ]]; then
             pushd "$(brew --repo)"


### PR DESCRIPTION
boost jfrog download url is down.
Same issue: https://github.com/boostorg/boost/issues/842

So I change the download url to boost io temporarylly.