### PR TITLE
(fix)[mlk] if sb_getenc is unknown, then sb_stemmer_new API will leak mem

### DIFF
--- a/src/contribs-lib/CLucene/snowball/libstemmer/libstemmer.c
+++ b/src/contribs-lib/CLucene/snowball/libstemmer/libstemmer.c
@@ -39,7 +39,11 @@ sb_stemmer_new(const char * algorithm, const char * charenc)
 	    (struct sb_stemmer *) malloc(sizeof(struct sb_stemmer));
     if (stemmer == NULL) return NULL;
     enc = sb_getenc(charenc);
-    if (enc == ENC_UNKNOWN) return NULL;
+    if (enc == ENC_UNKNOWN)
+    {
+        free(stemmer);
+        return NULL;
+    }
 
     for (module = modules; module->name != 0; module++) {
 	if (strcmp(module->name, algorithm) == 0 && module->enc == enc) break;


### PR DESCRIPTION
vallish@Vallishs-MacBook-Air doris-thirdparty % cat check.txt | grep memleak
src/contribs-lib/CLucene/snowball/libstemmer/libstemmer.c:42:29: error: Memory leak: stemmer [memleak]

in failure path added free for the pointer.