### PR TITLE
[Pick 2.0](index writer) fix dead lock when closeInternal catches CLuceneError (#207)

### DIFF
--- a/src/core/CLucene/index/IndexWriter.cpp
+++ b/src/core/CLucene/index/IndexWriter.cpp
@@ -596,8 +596,6 @@ void IndexWriter::closeInternal(bool waitForMerges) {
     } catch (std::bad_alloc &) {
         hitOOM = true;
         _CLTHROWA(CL_ERR_OutOfMemory, "Out of memory");
-    } catch (CLuceneError &e) {
-        throw e;
     }
     _CLFINALLY(
             {


### PR DESCRIPTION
From #207 
This pull request addresses an issue within the closeInternal method.  When Thread A invokes closeInternal and encounters a CLucene error, the method exits without setting the closing flag back to false.  As a result, if another Thread B subsequently calls closeInternal and enters the waitForClose method, it becomes trapped in an infinite loop.