### PR TITLE
[Fix](index writer) fix core if docWriter nullptr when IndexWriter doFlush

### DIFF
--- a/src/core/CLucene/index/IndexWriter.cpp
+++ b/src/core/CLucene/index/IndexWriter.cpp
@@ -2048,6 +2048,11 @@ void IndexWriter::flush(bool triggerMerge, bool _flushDocStores) {
 bool IndexWriter::doFlush(bool _flushDocStores) {
     SCOPED_LOCK_MUTEX(THIS_LOCK)
 
+    // if docWriter is nullptr, maybe it's been flushed already
+    if (docWriter == nullptr) {
+        return false;
+    }
+
     // Make sure no threads are actively adding a document
 
     // Returns true if docWriter is currently aborting, in


### PR DESCRIPTION
clucene will coredump if doris try to re-close index writer when encountering error in dir->close(), because in this situation, doc writer is already deleted and set to nullptr