### PR TITLE
[FIX] fix fieldDataArray.values is nullptr when meet first empty array

### DIFF
--- a/src/core/CLucene/index/SDocumentWriter.cpp
+++ b/src/core/CLucene/index/SDocumentWriter.cpp
@@ -131,7 +131,12 @@ void SDocumentsWriter<T>::ThreadState::resetCurrentFieldData(Document *doc) {
     const Document::FieldsType &docFields = *doc->getFields();
     const int32_t numDocFields = docFields.size();
 
-    if (FieldData* fp = fieldDataArray.values[0]; fp && numDocFields > 0) {
+    if (FieldData* fp = fieldDataArray.values[0]; numDocFields > 0) {
+        // maybe here fp has not been initialized
+        if (!fp) {
+            init(doc, docID+1);
+            fp = fieldDataArray.values[0];
+        }
         numFieldData = 1;
         // reset fp for new fields
         fp->fieldCount = 0;


### PR DESCRIPTION
if first is empty array in coming batch data
fieldDataArray.values would not be initialized in ThreadState.init method, 
then next array which to be inverted index will not be reset in Field because of this condition. so we can init with this current doc also here has more than one fields