### PR TITLE
[chore](workflow) Use GitHub Actions to build arm64 packages

### DIFF
--- a/.github/workflows/build-1.2.yml
+++ b/.github/workflows/build-1.2.yml
@@ -34,7 +34,7 @@ jobs:
       should_release: ${{ steps.check_diff.outputs.should_release }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'apache/doris'
           ref: 'branch-1.2-lts'
@@ -101,9 +101,35 @@ jobs:
     strategy:
       matrix:
         config:
-          - name: macOS
-            os: macos-12
+          - name: macOS-x86_64
+            os: macos-13
             packages: >-
+              'm4'
+              'automake'
+              'autoconf'
+              'libtool'
+              'pkg-config'
+              'texinfo'
+              'coreutils'
+              'gnu-getopt'
+              'python@3'
+              'cmake'
+              'ninja'
+              'ccache'
+              'bison'
+              'byacc'
+              'gettext'
+              'wget'
+              'pcre'
+              'openjdk@11'
+              'maven'
+              'node'
+              'llvm@15'
+
+          - name: macOS-arm64
+            os: macos-14
+            packages: >-
+              'm4'
               'automake'
               'autoconf'
               'libtool'
@@ -157,7 +183,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'apache/doris'
           ref: 'branch-1.2-lts'
@@ -174,8 +200,8 @@ jobs:
 
       - name: Prepare for ${{ matrix.config.os }}
         run: |
-          if [[ "${{ matrix.config.name }}" == 'macOS' ]]; then
-            brew install ${{ matrix.config.packages }}
+          if [[ "${{ matrix.config.name }}" =~ macOS-* ]]; then
+            brew install ${{ matrix.config.packages }} || true
           else
             export DEFAULT_DIR='/opt/doris'
             export PATH="${DEFAULT_DIR}/ldb-toolchain/bin:${PATH}"
@@ -199,6 +225,8 @@ jobs:
             export PATH="$(find /usr/lib/jvm/java-8-openjdk* -maxdepth 1 -type d -name 'bin'):${PATH}"
             export JAVA_HOME="$(find /usr/lib/jvm/java-8-openjdk* -maxdepth 0)"
             export DORIS_TOOLCHAIN=gcc
+          else
+            export MACOSX_DEPLOYMENT_TARGET=12.0
           fi
 
           cd thirdparty

--- a/.github/workflows/build-2.0.yml
+++ b/.github/workflows/build-2.0.yml
@@ -34,7 +34,7 @@ jobs:
       should_release: ${{ steps.check_diff.outputs.should_release }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'apache/doris'
           ref: 'branch-2.0'
@@ -101,9 +101,35 @@ jobs:
     strategy:
       matrix:
         config:
-          - name: macOS
-            os: macos-12
+          - name: macOS-x86_64
+            os: macos-13
             packages: >-
+              'm4'
+              'automake'
+              'autoconf'
+              'libtool'
+              'pkg-config'
+              'texinfo'
+              'coreutils'
+              'gnu-getopt'
+              'python@3'
+              'cmake'
+              'ninja'
+              'ccache'
+              'bison'
+              'byacc'
+              'gettext'
+              'wget'
+              'pcre'
+              'openjdk@11'
+              'maven'
+              'node'
+              'llvm@16'
+
+          - name: macOS-arm64
+            os: macos-14
+            packages: >-
+              'm4'
               'automake'
               'autoconf'
               'libtool'
@@ -174,7 +200,7 @@ jobs:
             remove-docker-images: 'true'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'apache/doris'
           ref: 'branch-2.0'
@@ -191,8 +217,8 @@ jobs:
 
       - name: Prepare for ${{ matrix.config.os }}
         run: |
-          if [[ "${{ matrix.config.name }}" == 'macOS' ]]; then
-            brew install ${{ matrix.config.packages }}
+          if [[ "${{ matrix.config.name }}" =~ macOS-* ]]; then
+            brew install ${{ matrix.config.packages }} || true
           else
             export DEFAULT_DIR='/opt/doris'
             export PATH="${DEFAULT_DIR}/ldb-toolchain/bin:${PATH}"
@@ -216,6 +242,8 @@ jobs:
             export PATH="$(find /usr/lib/jvm/java-8-openjdk* -maxdepth 1 -type d -name 'bin'):${PATH}"
             export JAVA_HOME="$(find /usr/lib/jvm/java-8-openjdk* -maxdepth 0)"
             export DORIS_TOOLCHAIN=gcc
+          else
+            export MACOSX_DEPLOYMENT_TARGET=12.0
           fi
 
           cd thirdparty

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       should_release: ${{ steps.check_diff.outputs.should_release }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'apache/doris'
           fetch-depth: 0
@@ -95,9 +95,35 @@ jobs:
     strategy:
       matrix:
         config:
-          - name: macOS
-            os: macos-12
+          - name: macOS-x86_64
+            os: macos-13
             packages: >-
+              'm4'
+              'automake'
+              'autoconf'
+              'libtool'
+              'pkg-config'
+              'texinfo'
+              'coreutils'
+              'gnu-getopt'
+              'python@3'
+              'cmake'
+              'ninja'
+              'ccache'
+              'bison'
+              'byacc'
+              'gettext'
+              'wget'
+              'pcre'
+              'openjdk@11'
+              'maven'
+              'node'
+              'llvm@16'
+
+          - name: macOS-arm64
+            os: macos-14
+            packages: >-
+              'm4'
               'automake'
               'autoconf'
               'libtool'
@@ -168,7 +194,7 @@ jobs:
             remove-docker-images: 'true'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'apache/doris'
 
@@ -181,8 +207,8 @@ jobs:
 
       - name: Prepare for ${{ matrix.config.os }}
         run: |
-          if [[ "${{ matrix.config.name }}" == 'macOS' ]]; then
-            brew install ${{ matrix.config.packages }}
+          if [[ "${{ matrix.config.name }}" =~ macOS-* ]]; then
+            brew install ${{ matrix.config.packages }} || true
           else
             export DEFAULT_DIR='/opt/doris'
             export PATH="${DEFAULT_DIR}/ldb-toolchain/bin:${PATH}"
@@ -204,6 +230,8 @@ jobs:
             export PATH="$(find /usr/lib/jvm/java-8-openjdk* -maxdepth 1 -type d -name 'bin'):${PATH}"
             export JAVA_HOME="$(find /usr/lib/jvm/java-8-openjdk* -maxdepth 0)"
             export DORIS_TOOLCHAIN=gcc
+          else
+            export MACOSX_DEPLOYMENT_TARGET=12.0
           fi
 
           cd thirdparty


### PR DESCRIPTION
Recently, GitHub actions provide macOS arm64 environment to run workflows. Therefore, we can use this environment to build our macOS arm64 packages.