### PR TITLE
[fix](inverted index) fix the heap-buffer-overflow issue in clucene slop_phrase_query

### DIFF
--- a/src/core/CLucene/search/SloppyPhraseScorer.cpp
+++ b/src/core/CLucene/search/SloppyPhraseScorer.cpp
@@ -112,7 +112,7 @@ CL_NS_DEF(search)
 		  }
 		  if (m!=NULL) {
 			  repeatsLen = m->size();
-			  repeats = _CL_NEWARRAY(PhrasePositions*, repeatsLen + 1);
+			  repeats = _CL_NEWARRAY(PhrasePositions*, repeatsLen + 2);
 			  PhrasePositionsMap::iterator itr = m->begin();
 			  size_t pos = 0;
 			  while ( itr!=m->end() ){


### PR DESCRIPTION
1. occurs when the same term appears in a phrase query