### PR TITLE
fix CLStream memcpy read 1 extra byte

### DIFF
--- a/src/core/CLucene/util/CLStreams.h
+++ b/src/core/CLucene/util/CLStreams.h
@@ -207,7 +207,8 @@ public:
                 tmp = (T *) realloc(tmp, sizeof(T) * (length + 1));
                 this->buffer_size = length;
             }
-            memcpy(tmp, _value, length + 1);
+            memcpy(tmp, _value, length);
+            tmp[length] = 0;
             this->value = tmp;
         } else {
             if (ownValue && this->value != NULL) {

--- a/src/core/CLucene/util/CLStreams.h
+++ b/src/core/CLucene/util/CLStreams.h
@@ -195,6 +195,8 @@ public:
         this->buffer_size = 0;
         this->init(_value, _length, copyData);
     }
+
+    // _value should be type T*
     void init(const void *_value, int32_t _length, bool copyData = true) override {
         const size_t length = (size_t)_length;
         this->pos = 0;
@@ -207,7 +209,9 @@ public:
                 tmp = (T *) realloc(tmp, sizeof(T) * (length + 1));
                 this->buffer_size = length;
             }
-            memcpy(tmp, _value, length);
+            // copy data
+            memcpy(tmp, _value, length * sizeof(T));
+            // add trailing zero
             tmp[length] = 0;
             this->value = tmp;
         } else {
@@ -225,6 +229,15 @@ public:
             auto *v = (T *) this->value;
             _CLDELETE_LARRAY(v);
             this->value = NULL;
+        }
+    }
+
+    // for test only
+    int testValueAt(const size_t i) {
+        if (i <= this->m_size) {
+            return this->value[i];
+        } else {
+            return -1;
         }
     }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -101,6 +101,7 @@ SET(test_files ./tests.cpp
         ./util/TestBKD.cpp
         ./util/TestMSBRadixSorter.cpp
         ./util/TestStringBuffer.cpp
+        ./util/TestStringReader.cpp
         ./util/English.cpp
         ./util/TestStrConvert.cpp
         ./query/TestMultiPhraseQuery.cpp

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -84,6 +84,7 @@ CuSuite *testStrConvert(void);
 CuSuite *testSearchRange(void);
 CuSuite *testMultiPhraseQuery(void);
 CuSuite *testIndexCompaction(void);
+CuSuite *testStringReader(void);
 
 #ifdef TEST_CONTRIB_LIBS
 //CuSuite *testGermanAnalyzer(void);

--- a/src/test/tests.cpp
+++ b/src/test/tests.cpp
@@ -18,6 +18,7 @@ unittest tests[] = {
         {"searchRange", testSearchRange},
         {"MultiPhraseQuery", testMultiPhraseQuery},
         {"IndexCompaction", testIndexCompaction},
+        {"testStringReader", testStringReader},
 #ifdef TEST_CONTRIB_LIBS
         {"chinese", testchinese},
 #endif

--- a/src/test/util/TestStringReader.cpp
+++ b/src/test/util/TestStringReader.cpp
@@ -1,0 +1,83 @@
+/*------------------------------------------------------------------------------
+* Copyright (C) 2003-2010 Ben van Klinken and the CLucene Team
+*
+* Distributable under the terms of either the Apache License (Version 2.0) or
+* the GNU Lesser General Public License, as specified in the COPYING file.
+------------------------------------------------------------------------------*/
+
+#include "test.h"
+#include "CLucene/util/CLStreams.h"
+#include <stdexcept>
+
+CL_NS_USE(util)
+
+void testSStringReaderInit(CuTest *tc) {
+  // test for char
+  // test default constructor and internal status
+  SStringReader<char> r11;
+  CuAssertEquals(tc, 0, r11.size());
+  CuAssertEquals(tc, 0, r11.position());
+
+  char chars[5] = {'t', 'e', 's', 't', 'x'};
+
+  // test constructor without copy and internal status
+  SStringReader<char> r12 {chars, 4, false};
+  CuAssertEquals(tc, 4, r12.size());
+  CuAssertEquals(tc, 0, r12.position());
+  CuAssertEquals(tc, 't', r12.testValueAt(0));
+  CuAssertEquals(tc, 'e', r12.testValueAt(1));
+  CuAssertEquals(tc, 's', r12.testValueAt(2));
+  CuAssertEquals(tc, 't', r12.testValueAt(3));
+  // it is 'x' as original chars since not copying 
+  CuAssertEquals(tc, 'x', r12.testValueAt(4));
+
+  // test constructor with copy and internal status
+  SStringReader<char> r13 {chars, 4, true};
+  CuAssertEquals(tc, 4, r13.size());
+  CuAssertEquals(tc, 0, r13.position());
+  CuAssertEquals(tc, 't', r13.testValueAt(0));
+  CuAssertEquals(tc, 'e', r13.testValueAt(1));
+  CuAssertEquals(tc, 's', r13.testValueAt(2));
+  CuAssertEquals(tc, 't', r13.testValueAt(3));
+  // it is 0 since only copying 4 chars and add 0
+  CuAssertEquals(tc, 0, r13.testValueAt(4));
+
+
+  // test for wchar
+  // test default constructor and internal status
+  SStringReader<wchar_t> r21;
+  CuAssertEquals(tc, 0, r21.size());
+  CuAssertEquals(tc, 0, r21.position());
+
+  wchar_t wchars[5] = {'t', 'e', 's', 't', 'x'};
+
+  // test constructor without copy and internal status
+  SStringReader<wchar_t> r22 {wchars, 4, false};
+  CuAssertEquals(tc, 4, r22.size());
+  CuAssertEquals(tc, 0, r22.position());
+  CuAssertEquals(tc, 't', r22.testValueAt(0));
+  CuAssertEquals(tc, 'e', r22.testValueAt(1));
+  CuAssertEquals(tc, 's', r22.testValueAt(2));
+  CuAssertEquals(tc, 't', r22.testValueAt(3));
+  // it is 'x' as original chars since not copying 
+  CuAssertEquals(tc, 'x', r22.testValueAt(4));
+
+  // test constructor with copy and internal status
+  SStringReader<wchar_t> r23 {wchars, 4, true};
+  CuAssertEquals(tc, 4, r23.size());
+  CuAssertEquals(tc, 0, r23.position());
+  CuAssertEquals(tc, 't', r23.testValueAt(0));
+  CuAssertEquals(tc, 'e', r23.testValueAt(1));
+  CuAssertEquals(tc, 's', r23.testValueAt(2));
+  CuAssertEquals(tc, 't', r23.testValueAt(3));
+  // it is 0 since only copying 4 chars and add 0
+  CuAssertEquals(tc, 0, r23.testValueAt(4));
+}
+
+CuSuite *testStringReader(void) {
+    CuSuite *suite = CuSuiteNew(_T("CLucene SStringReader Test"));
+
+    SUITE_ADD_TEST(suite, testSStringReaderInit);
+
+    return suite;
+}


### PR DESCRIPTION
It should only copy the length passed from argument, instead of `length + 1`, which may cause ASAN global-buffer-overflow.

```
    void init(const void *_value, int32_t _length, bool copyData = true) override {
        const size_t length = _length;
        this->pos = 0;
        if (copyData) {
            T *tmp = (T *) this->value;
            if (tmp == NULL || !this->ownValue) {
                tmp = _CL_NEWARRAY(T, length + 1);
                this->buffer_size = length;
            } else if (length > this->buffer_size || length < (this->buffer_size / 2)) {//expand, or shrink
                tmp = (T *) realloc(tmp, sizeof(T) * (length + 1));
                this->buffer_size = length;
            }
            memcpy(tmp, _value, length + 1);  ///////////////// THIS IS THE BUGGY LINE  //////////
            this->value = tmp;
        } else {
            if (ownValue && this->value != NULL) {
                _CLDELETE_LARRAY((T *) this->value);
            }
            this->value = (T *)_value;
            this->buffer_size = 0;
        }
        this->m_size = length;
        this->ownValue = copyData;
    };

```