### PR TITLE
[fix](workflow)Update macOS version to 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         config:
           - name: macOS
-            os: macos-12
+            os: macos-15
             packages: >-
               'automake'
               'autoconf'


### PR DESCRIPTION
macOS 12 is deprecation now, we will update to 15. 
More detail: https://github.com/actions/runner-images/issues/10721