### PR TITLE
[fix](bkd) make ram_bytes_used for bkd reader public

### DIFF
--- a/src/core/CLucene/util/bkd/bkd_reader.h
+++ b/src/core/CLucene/util/bkd/bkd_reader.h
@@ -160,9 +160,9 @@ public:
                    std::vector<uint8_t> &cellMinPacked,
                    std::vector<uint8_t> &cellMaxPacked);
     std::shared_ptr<intersect_state> get_intersect_state(bkd_reader::intersect_visitor *visitor);
+    int64_t ram_bytes_used();
 
 private:
-    int64_t ram_bytes_used();
     store::Directory* _dir;
     bool _close_directory;
 };


### PR DESCRIPTION
Make ram_bytes_used public because doris need to use it to calculate memory used