### PR TITLE
Revert "[fix](tgt)hadoop kerberos support renew TGT by keytab (#173)"

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -582,19 +582,6 @@ public abstract class FileSystem extends Configured
     });
   }
 
-  public synchronized static FileSystem newInstanceFromKeytab(final URI uri, final Configuration conf,
-                                                              final String principal, final String keytabPath)
-          throws IOException, InterruptedException {
-    UserGroupInformation.setConfiguration(conf);
-    UserGroupInformation.loginUserFromKeytab(principal, keytabPath);
-    return UserGroupInformation.getLoginUser().doAs(new PrivilegedExceptionAction<FileSystem>() {
-      @Override
-      public FileSystem run() throws IOException {
-        return newInstance(uri, conf);
-      }
-    });
-  }
-
   /**
    * Returns the FileSystem for this URI's scheme and authority.
    * The entire URI is passed to the FileSystem instance's initialize method.

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c
@@ -36,7 +36,6 @@
 #define JMETHOD1(X, R)      "(" X ")" R
 #define JMETHOD2(X, Y, R)   "(" X Y ")" R
 #define JMETHOD3(X, Y, Z, R)   "(" X Y Z")" R
-#define JMETHOD4(X, Y, Z, A, R)   "(" X Y Z A")" R
 
 #define KERBEROS_TICKET_CACHE_PATH "hadoop.security.kerberos.ticket.cache.path"
 
@@ -537,7 +536,6 @@ struct hdfsBuilder {
     const char *kerbTicketCachePath;
     const char *kerb5ConfPath;
     const char *keyTabFile;
-    const char *kerbPrincipal;
     const char *userName;
     struct hdfsBuilderConfOpt *opts;
     struct hdfsBuilderConfFileOpt *fileOpts;
@@ -656,11 +654,6 @@ void hdfsBuilderSetNameNodePort(struct hdfsBuilder *bld, tPort port)
 void hdfsBuilderSetUserName(struct hdfsBuilder *bld, const char *userName)
 {
     bld->userName = userName;
-}
-
-void hdfsBuilderSetPrincipal(struct hdfsBuilder *bld, const char *kerbPrincipal)
-{
-    bld->kerbPrincipal = kerbPrincipal;
 }
 
 void hdfsBuilderSetKerbTicketCachePath(struct hdfsBuilder *bld,
@@ -800,7 +793,7 @@ hdfsFS hdfsBuilderConnect(struct hdfsBuilder *bld)
 {
     JNIEnv *env = 0;
     jobject jConfiguration = NULL, jFS = NULL, jURI = NULL, jCachePath = NULL;
-    jstring jURIString = NULL, jUserString = NULL, jPrincipalString = NULL, jKeyTabString = NULL;
+    jstring jURIString = NULL, jUserString = NULL, jKeyTabString = NULL;
     jvalue  jVal;
     jthrowable jthr = NULL;
     char *cURI = 0, buf[512];
@@ -867,7 +860,7 @@ hdfsFS hdfsBuilderConnect(struct hdfsBuilder *bld)
             // fs = FileSytem#getLocal(conf);
             jthr = invokeMethod(env, &jVal, STATIC, NULL,
                     JC_FILE_SYSTEM, "getLocal",
-                    JMETHOD1(JPARAM(HADOOP_CONF)    , JPARAM(HADOOP_LOCALFS)),
+                    JMETHOD1(JPARAM(HADOOP_CONF), JPARAM(HADOOP_LOCALFS)),
                     jConfiguration);
             if (jthr) {
                 ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
@@ -922,7 +915,23 @@ hdfsFS hdfsBuilderConnect(struct hdfsBuilder *bld)
                                         hdfsBuilderToStr(bld, buf, sizeof(buf)));
             goto done;
         }
-        if (bld->kerbTicketCachePath) {
+        if (bld->kerb5ConfPath && bld->keyTabFile) {
+            jthr = invokeMethod(env, NULL, STATIC, NULL, JC_SECURITY_CONFIGURATION, "setConfiguration", JMETHOD1(JPARAM(HADOOP_CONF),JAVA_VOID), jConfiguration);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,"hdfsBuilderConnect(%s)", hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+            jthr = newJavaStr(env, bld->keyTabFile, &jKeyTabString);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,"hdfsBuilderConnect(%s)", hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+            jthr = invokeMethod(env, NULL, STATIC, NULL, JC_SECURITY_CONFIGURATION, "loginUserFromKeytab", JMETHOD2(JPARAM(JAVA_STRING), JPARAM(JAVA_STRING), JAVA_VOID), jUserString, jKeyTabString);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,"hdfsBuilderConnect(%s)", hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
+            }
+        } else if (bld->kerbTicketCachePath) {
             jthr = hadoopConfSetStr(env, jConfiguration,
                 KERBEROS_TICKET_CACHE_PATH, bld->kerbTicketCachePath);
             if (jthr) {
@@ -935,69 +944,20 @@ hdfsFS hdfsBuilderConnect(struct hdfsBuilder *bld)
             JMETHOD1(JPARAM(HADOOP_CONF),JAVA_VOID), jConfiguration);
         }
         if (bld->forceNewInstance) {
-            // need kerb5ConfPath to enable kerberos authentication
-            if (bld->kerb5ConfPath && bld->kerbPrincipal && bld->keyTabFile) {
-                jthr = newJavaStr(env, bld->kerbPrincipal, &jPrincipalString);
-                if (jthr) {
-                    ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
-                                                "hdfsBuilderConnect(%s)",
-                                                hdfsBuilderToStr(bld, buf, sizeof(buf)));
-                    goto done;
-                }
-                jthr = newJavaStr(env, bld->keyTabFile, &jKeyTabString);
-                if (jthr) {
-                    ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,"hdfsBuilderConnect(%s)", hdfsBuilderToStr(bld, buf, sizeof(buf)));
-                    goto done;
-                }
-                jthr = invokeMethod(env, &jVal, STATIC, NULL,
-                                    JC_FILE_SYSTEM, "newInstanceFromKeytab",
-                                    JMETHOD4(JPARAM(JAVA_NET_URI), JPARAM(HADOOP_CONF),
-                                             JPARAM(JAVA_STRING), JPARAM(JAVA_STRING), JPARAM(HADOOP_FS)), jURI,
-                                    jConfiguration, jPrincipalString, jKeyTabString);
-                if (jthr) {
-                    ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
-                                                "hdfsBuilderConnect(%s)",
-                                                hdfsBuilderToStr(bld, buf, sizeof(buf)));
-                    goto done;
-                }
-            } else {
-                jthr = invokeMethod(env, &jVal, STATIC, NULL,
-                                    JC_FILE_SYSTEM, "newInstance",
-                                    JMETHOD3(JPARAM(JAVA_NET_URI), JPARAM(HADOOP_CONF),
-                                             JPARAM(JAVA_STRING), JPARAM(HADOOP_FS)), jURI,
-                                    jConfiguration, jUserString);
-                if (jthr) {
-                    ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
-                                                "hdfsBuilderConnect(%s)",
-                                                hdfsBuilderToStr(bld, buf, sizeof(buf)));
-                    goto done;
-                }
+            jthr = invokeMethod(env, &jVal, STATIC, NULL,
+                    JC_FILE_SYSTEM, "newInstance",
+                    JMETHOD3(JPARAM(JAVA_NET_URI), JPARAM(HADOOP_CONF),
+                             JPARAM(JAVA_STRING), JPARAM(HADOOP_FS)), jURI,
+                    jConfiguration, jUserString);
+            if (jthr) {
+                ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
+                    "hdfsBuilderConnect(%s)",
+                    hdfsBuilderToStr(bld, buf, sizeof(buf)));
+                goto done;
             }
             jFS = jVal.l;
         } else {
-            if (bld->keyTabFile && bld->kerb5ConfPath && bld->kerbPrincipal) {
-                jthr = newJavaStr(env, bld->kerbPrincipal, &jPrincipalString);
-                if (jthr) {
-                    ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,
-                                                "hdfsBuilderConnect(%s)",
-                                                hdfsBuilderToStr(bld, buf, sizeof(buf)));
-                    goto done;
-                }
-                jthr = invokeMethod(env, NULL, STATIC, NULL, JC_SECURITY_CONFIGURATION, "setConfiguration", JMETHOD1(JPARAM(HADOOP_CONF),JAVA_VOID), jConfiguration);
-                if (jthr) {
-                    ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,"hdfsBuilderConnect(%s)", hdfsBuilderToStr(bld, buf, sizeof(buf)));
-                    goto done;
-                }
-                jthr = newJavaStr(env, bld->keyTabFile, &jKeyTabString);
-                if (jthr) {
-                    ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,"hdfsBuilderConnect(%s)", hdfsBuilderToStr(bld, buf, sizeof(buf)));
-                    goto done;
-                }
-                jthr = invokeMethod(env, NULL, STATIC, NULL, JC_SECURITY_CONFIGURATION, "loginUserFromKeytab", JMETHOD2(JPARAM(JAVA_STRING), JPARAM(JAVA_STRING), JAVA_VOID), jPrincipalString, jKeyTabString);
-                if (jthr) {
-                    ret = printExceptionAndFree(env, jthr, PRINT_EXC_ALL,"hdfsBuilderConnect(%s)", hdfsBuilderToStr(bld, buf, sizeof(buf)));
-                    goto done;
-                }
+            if (bld->keyTabFile && bld->kerb5ConfPath) {
                 jthr = invokeMethod(env, &jVal, STATIC, NULL, JC_FILE_SYSTEM, "get", JMETHOD1(JPARAM(HADOOP_CONF),
                 JPARAM(HADOOP_FS)), jConfiguration);
             } else {

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/include/hdfs/hdfs.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/include/hdfs/hdfs.h
@@ -363,6 +363,15 @@ extern  "C" {
     LIBHDFS_EXTERNAL
     void hdfsBuilderSetUserName(struct hdfsBuilder *bld, const char *userName);
 
+	/**
+     * Set the principal to use when connecting to the HDFS cluster.
+     *
+     * @param bld The HDFS builder
+     * @param kerbPrincipal The principal.  The string will be shallow-copied.
+     */
+    LIBHDFS_EXTERNAL
+    void hdfsBuilderSetPrincipal(struct hdfsBuilder *bld, const char *kerbPrincipal);
+
     /**
      * Set the path to the Kerberos ticket cache to use when connecting to
      * the HDFS cluster.

--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/include/hdfs/hdfs.h
+++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/include/hdfs/hdfs.h
@@ -362,15 +362,6 @@ extern  "C" {
      */
     LIBHDFS_EXTERNAL
     void hdfsBuilderSetUserName(struct hdfsBuilder *bld, const char *userName);
-    
-    /**
-    * Set the principal to use when connecting to the HDFS cluster.
-    *
-    * @param bld The HDFS builder
-    * @param kerbPrincipal The principal.  The string will be shallow-copied.
-    */
-    LIBHDFS_EXTERNAL
-    void hdfsBuilderSetPrincipal(struct hdfsBuilder *bld, const char *kerbPrincipal);
 
     /**
      * Set the path to the Kerberos ticket cache to use when connecting to


### PR DESCRIPTION
The PR #173 is wrong, we don't need `newInstanceFromKeyTab()` method.
But keep the `hdfsBuilderSetPrincipal()` method because in hdfs.c
It use `user` to login kerberos but use `user` again to do SIMPLE authentication, which I think is a bug.