### PR TITLE
[Fix] Revert PR309 computeRGIdx() changes, it will fix in the next PR.

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1407,7 +1407,7 @@ namespace orc {
    * @return Id of the RowGroup that the row belongs to
    */
   int RowReaderImpl::computeRGIdx(uint64_t rowIndexStride, long rowIdx) {
-    return rowIndexStride == 0 ? 0 : static_cast<int>(rowIdx / static_cast<long>(rowIndexStride));
+    return rowIndexStride == 0 ? 0 : (int)(rowIdx / rowIndexStride);
   }
 
   /**


### PR DESCRIPTION
[Fix] Revert `computeRGIdx()` changes in #309, it will fix in the next PR.