### PR TITLE
[fix] Fix complex type late materialization.

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -1158,7 +1158,9 @@ namespace orc {
   }
 
   uint64_t StructColumnReader::skip(uint64_t numValues, const ReadPhase& readPhase) {
-    numValues = ColumnReader::skip(numValues, readPhase);
+    if (readPhase.contains(this->type.getReaderCategory())) {
+      numValues = ColumnReader::skip(numValues, readPhase);
+    }
     for (auto& ptr : children) {
       if (shouldProcessChild(ptr->getType().getReaderCategory(), readPhase)) {
         ptr->skip(numValues, readPhase);
@@ -1183,7 +1185,9 @@ namespace orc {
   void StructColumnReader::nextInternal(ColumnVectorBatch& rowBatch, uint64_t numValues,
                                         char* notNull, const ReadPhase& readPhase,
                                         uint16_t* sel_rowid_idx, size_t sel_size) {
-    ColumnReader::next(rowBatch, numValues, notNull, readPhase, sel_rowid_idx, sel_size);
+    if (readPhase.contains(this->type.getReaderCategory())) {
+      ColumnReader::next(rowBatch, numValues, notNull, readPhase, sel_rowid_idx, sel_size);
+    }
     uint64_t i = 0;
     notNull = rowBatch.hasNulls ? rowBatch.notNull.data() : nullptr;
     for (auto iter = children.begin(); iter != children.end(); ++iter, ++i) {
@@ -1201,7 +1205,9 @@ namespace orc {
 
   void StructColumnReader::seekToRowGroup(std::unordered_map<uint64_t, PositionProvider>& positions,
                                           const ReadPhase& readPhase) {
-    ColumnReader::seekToRowGroup(positions, readPhase);
+    if (readPhase.contains(this->type.getReaderCategory())) {
+      ColumnReader::seekToRowGroup(positions, readPhase);
+    }
 
     for (auto& ptr : children) {
       if (shouldProcessChild(ptr->getType().getReaderCategory(), readPhase)) {
@@ -1579,6 +1585,9 @@ namespace orc {
   }
 
   uint64_t UnionColumnReader::skip(uint64_t numValues, const ReadPhase& readPhase) {
+    if (!readPhase.contains(this->type.getReaderCategory())) {
+      throw NotImplementedYet("Not implemented yet");
+    }
     numValues = ColumnReader::skip(numValues, readPhase);
     const uint64_t BUFFER_SIZE = 1024;
     char buffer[BUFFER_SIZE];
@@ -1618,6 +1627,9 @@ namespace orc {
   void UnionColumnReader::nextInternal(ColumnVectorBatch& rowBatch, uint64_t numValues,
                                        char* notNull, const ReadPhase& readPhase,
                                        uint16_t* sel_rowid_idx, size_t sel_size) {
+    if (!readPhase.contains(this->type.getReaderCategory())) {
+      throw NotImplementedYet("Not implemented yet");
+    }
     ColumnReader::next(rowBatch, numValues, notNull, readPhase);
     UnionVectorBatch& unionBatch = dynamic_cast<UnionVectorBatch&>(rowBatch);
     uint64_t* offsets = unionBatch.offsets.data();
@@ -1655,6 +1667,9 @@ namespace orc {
 
   void UnionColumnReader::seekToRowGroup(std::unordered_map<uint64_t, PositionProvider>& positions,
                                          const ReadPhase& readPhase) {
+    if (!readPhase.contains(this->type.getReaderCategory())) {
+      throw NotImplementedYet("Not implemented yet");
+    }
     ColumnReader::seekToRowGroup(positions, readPhase);
     rle->seek(positions.at(columnId));
     for (size_t i = 0; i < numChildren; ++i) {

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -26,9 +26,9 @@
 namespace orc {
 
   const ReadPhase ReadPhase::ALL = ReadPhase::fromCategories(
-      {ReaderCategory::FILTER_CHILD, ReaderCategory::FILTER_PARENT, ReaderCategory::NON_FILTER});
+      {ReaderCategory::FILTER_CHILD, ReaderCategory::FILTER_PARENT, ReaderCategory::FILTER_COMPOUND_ELEMENT, ReaderCategory::NON_FILTER});
   const ReadPhase ReadPhase::LEADERS =
-      ReadPhase::fromCategories({ReaderCategory::FILTER_CHILD, ReaderCategory::FILTER_PARENT});
+      ReadPhase::fromCategories({ReaderCategory::FILTER_CHILD, ReaderCategory::FILTER_COMPOUND_ELEMENT, ReaderCategory::FILTER_PARENT});
   const ReadPhase ReadPhase::FOLLOWERS = ReadPhase::fromCategories({ReaderCategory::NON_FILTER});
   const ReadPhase ReadPhase::LEADER_PARENTS =
       ReadPhase::fromCategories({ReaderCategory::FILTER_PARENT});


### PR DESCRIPTION
Fix complex type late materialization.

Currently Filter/Non Filter Node types:
```
/**
   * Filter Node Types:
   *
   * FILTER_CHILD: Primitive type that is a filter column.
   * FILTER_PARENT: Compound type that may contain both filter and non-filter children.
   * FILTER_COMPOUND_ELEMENT: Compound type that is a filter element (list/map).
   *                         The entire column will be read, and must have only filter children.
   * NON_FILTER: Non-filter column.
   *
   * Example:
   * struct<name:string,
   *        age:int,
   *        address:struct<city:string,
   *                       zip:int,
   *                       location:struct<latitude:double, longitude:double>>,
   *        hobbies:list<struct<name:string, level:int>>,
   *        scores:map<string, struct<subject:string, grade:int>>>
   *
   * Filter columns: name, address.city, address.location.latitude, hobbies, scores
   *
   * Column Structure:
   * struct<...>
   * ├── name (FILTER_CHILD)           # Primitive type, filter column
   * ├── age (NON_FILTER)              # Non-filter column
   * ├── address (FILTER_PARENT)       # Compound type with filter children
   * │   ├── city (FILTER_CHILD)       # Primitive type, filter column
   * │   ├── zip (NON_FILTER)          # Non-filter column
   * │   └── location (FILTER_PARENT)  # Compound type with filter children
   * │       ├── latitude (FILTER_CHILD)  # Primitive type, filter column
   * │       └── longitude (NON_FILTER)   # Non-filter column
   * ├── hobbies (FILTER_COMPOUND_ELEMENT)  # Compound type as filter element (list)
   * │   └── struct<name:string, level:int> (FILTER_PARENT)  # Compound type with filter children
   * │       ├── name (FILTER_CHILD)   # Primitive type, filter column
   * │       └── level (FILTER_CHILD)  # Primitive type, filter column
   * └── scores (FILTER_COMPOUND_ELEMENT)   # Compound type as filter element (map)
   *     ├── key (FILTER_CHILD)        # Primitive type, filter column
   *     └── value (FILTER_PARENT)     # Compound type with filter children
   *         ├── subject (FILTER_CHILD)  # Primitive type, filter column
   *         └── grade (FILTER_CHILD)    # Primitive type, filter column
   */
```