### PR TITLE
[fix] Load StripeIndex if searchArgument not exist when filter is not null.

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1235,6 +1235,11 @@ namespace orc {
             currentRowInStripe = 0;
             continue;
           }
+        } else {
+          if (filter) {
+            // read row group statistics and bloom filters of current stripe
+            loadStripeIndex();
+          }
         }
       }
 


### PR DESCRIPTION
Cherry-pick #301 #302