### PR TITLE
[fix] Updated ZlibDecompressionStreamByLibDeflate::getName() to be the same as ZlibDecompressionStream::getName() to keep unit tests correct.

### DIFF
--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -810,7 +810,7 @@ namespace orc {
 
     std::string getName() const override {
       std::ostringstream result;
-      result << "ZlibDecompressionStreamByLibDeflate(" << getStreamName() << ")";
+      result << "zlib(" << input->getName() << ")";
       return result.str();
     }
 


### PR DESCRIPTION
Cherry-pick #323 