### PR TITLE
[fix](index writer) remove unused deleter code

### DIFF
--- a/src/core/CLucene/index/IndexWriter.h
+++ b/src/core/CLucene/index/IndexWriter.h
@@ -230,7 +230,7 @@ class CLUCENE_EXPORT IndexWriter:LUCENE_BASE {
 
 
   bool commitPending; // true if segmentInfos has changes not yet committed
-  SegmentInfos* rollbackSegmentInfos;      // segmentInfos we will fallback to if the commit fails
+  //SegmentInfos* rollbackSegmentInfos;      // segmentInfos we will fallback to if the commit fails
 
   SegmentInfos* localRollbackSegmentInfos;      // segmentInfos we will fallback to if the commit fails
   bool localAutoCommit;                // saved autoCommit during local transaction
@@ -240,7 +240,7 @@ class CLUCENE_EXPORT IndexWriter:LUCENE_BASE {
   //typedef SDocumentsWriter<char> SDocumentsWriterType;
   //SDocumentsWriterType *sdocWriter;
   //lucene::index::SDocumentsWriter<char>* sdocWriter;
-  IndexFileDeleter* deleter;
+  //IndexFileDeleter* deleter;
 
   typedef std::vector<SegmentInfo*> SegmentsToOptimizeType;
   SegmentsToOptimizeType* segmentsToOptimize;           // used by optimize to note those needing optimization


### PR DESCRIPTION
deleter will cause memory leak, but we do not need that code in doris, so we delete it.