### PR TITLE
Kudu: add kudu.timezone for TIMESTAMP conversion

### DIFF
--- a/docs/src/main/sphinx/connector/kudu.md
+++ b/docs/src/main/sphinx/connector/kudu.md
@@ -56,6 +56,9 @@ kudu.client.master-addresses=localhost
 
 ## Assign Kudu splits to replica host if worker and kudu share the same cluster
 #kudu.allow-local-scheduling = false
+
+## Optional timezone used for TIMESTAMP values (default: UTC)
+#kudu.timezone = UTC
 ```
 
 ## Kerberos support

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientConfig.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientConfig.java
@@ -44,6 +44,7 @@ public class KuduClientConfig
     private String schemaEmulationPrefix = "presto::";
     private Duration dynamicFilteringWaitTimeout = new Duration(0, MINUTES);
     private boolean allowLocalScheduling;
+    private String timeZone = "UTC";
 
     @NotNull
     @Size(min = 1)
@@ -136,6 +137,19 @@ public class KuduClientConfig
     {
         this.dynamicFilteringWaitTimeout = dynamicFilteringWaitTimeout;
         return this;
+    }
+
+    @Config("kudu.timezone")
+    public KuduClientConfig setTimeZone(String timeZone)
+    {
+        this.timeZone = timeZone;
+        TimestampHelper.setTimeZoneOffset(TimestampHelper.getZoneOffset(timeZone));
+        return this;
+    }
+
+    public String getTimeZone()
+    {
+        return timeZone;
     }
 
     public boolean isAllowLocalScheduling()

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -157,7 +157,7 @@ public class KuduPageSink
             row.addDate(destChannel, epochDaysToSqlDate(INTEGER.getInt(block, position)));
         }
         else if (TIMESTAMP_MILLIS.equals(type)) {
-            row.addLong(destChannel, truncateEpochMicrosToMillis(TIMESTAMP_MILLIS.getLong(block, position)));
+            row.addLong(destChannel, truncateEpochMicrosToMillis(TIMESTAMP_MILLIS.getLong(block, position)) - (TimestampHelper.getTimeZoneOffset() * 1_000));
         }
         else if (REAL.equals(type)) {
             row.addFloat(destChannel, REAL.getFloat(block, position));

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TimestampHelper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TimestampHelper.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kudu;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+public final class TimestampHelper
+{
+    private TimestampHelper() {}
+
+    private static long timeZoneOffsetMillis;
+
+    public static long getTimeZoneOffset()
+    {
+        return timeZoneOffsetMillis;
+    }
+
+    public static void setTimeZoneOffset(long timeZoneOffsetMillis)
+    {
+        TimestampHelper.timeZoneOffsetMillis = timeZoneOffsetMillis;
+    }
+
+    public static long getZoneOffset(String zone)
+    {
+        ZoneId zoneId = ZoneId.of(zone);
+        ZoneOffset offset = zoneId.getRules().getOffset(Instant.now());
+        return offset.getTotalSeconds() * 1000L;
+    }
+}

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
@@ -173,7 +173,7 @@ public final class TypeHelper
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
             // Kudu's native format is in microseconds
-            return nativeValue;
+            return ((Long) nativeValue) - (TimestampHelper.getTimeZoneOffset() * 1_000);
         }
         throw new IllegalStateException("Back conversion not implemented for " + type);
     }
@@ -215,7 +215,7 @@ public final class TypeHelper
             return row.getInt(field);
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
-            return truncateEpochMicrosToMillis(row.getLong(field));
+            return truncateEpochMicrosToMillis(row.getLong(field)) + (TimestampHelper.getTimeZoneOffset() * 1_000);
         }
         throw new IllegalStateException("getLong not implemented for " + type);
     }


### PR DESCRIPTION
- Summary: Introduces `kudu.timezone` to control how TIMESTAMP values are conver
ted between Trino and Kudu,to ensure co
nsistent semantics when Kudu stores UTC timestamps while users expect local time
 interpretation.
- Changes:
  - KuduClientConfig: add `kudu.timezone` (default `UTC`), initialize timezone o
ffset via `TimestampHelper`.
  - TimestampHelper: new utility using `java.time` to compute zone offset in mil
liseconds and cache it.
  - KuduPageSink: when writing `TIMESTAMP_MILLIS`, subtract the offset (applied 
in microseconds).
  - TypeHelper: when reading `TIMESTAMP_MILLIS`, add the offset; adjust `getJava
Value` and `getLong`.
  - Docs: add `#kudu.timezone = UTC` to Kudu connector configuration docs.
- Usage:
  - Set in `etc/catalog/kudu.properties`: `kudu.timezone=Asia/Shanghai` (default
s to `UTC`).