### PR TITLE
add missing memory header for MemReader class

### DIFF
--- a/src/test/document/TestDocument.cpp
+++ b/src/test/document/TestDocument.cpp
@@ -10,6 +10,7 @@
 #include "CLucene/document/FieldSelector.h"
 #include "CLucene/index/SDocumentWriter.h"
 #include <nanobench.h>
+#include <memory>
 
 //an in memory input stream for testing binary data
 class MemReader : public CL_NS(util)::Reader {


### PR DESCRIPTION
## Environment

- **OS:** Ubuntu 24.10
- **Compiler:** GCC 14
- **Commit:** `b47f6972e66c47f7e17a2e411ce2cac2f2eeb52b`

---

## Steps to Reproduce

1.  Create a build directory and configure the project with tests enabled:
    ```bash
    cmake -DENABLE_TESTS=ON ..
    ```
2.  Run the build for the test target:
    ```bash
    make cl_test
    ```

---

## Observed Behavior

The compilation process fails when building `src/test/document/TestDocument.cpp`. The compiler reports that `std::make_unique` is not defined.

The key error from the compiler is:
```cpp
/path/to/doris-thirdparty/src/test/document/TestDocument.cpp:69:36: error: ‘make_unique’ is not a member of ‘std’
   69 |   auto char_string_reader = std::make_unique<lucene::util::SStringReader<char>>();
      |                                   ^~~~~~~~~~~
// Compiler Note:
/path/to/doris-thirdparty/src/test/document/TestDocument.cpp:13:1: note: ‘std::make_unique’ is defined in header ‘<memory>’; this is probably fixable by adding ‘#include <memory>’
   12 | #include <nanobench.h>
  +++ |+#include <memory>
   13 |
```
## Cause and Solution
The function `std::make_unique` was introduced in C++14 and is defined in the <memory> header. Newer compilers like GCC 14 are stricter about requiring explicit header includes.</memory>

Solution: Adding `#include <memory>` to the top of src/test/document/TestDocument.cpp resolves the compilation error.