### PR TITLE
[Fix](bdb) Fix feeder handshake error

### DIFF
--- a/src/main/java/com/sleepycat/je/rep/stream/FeederReplicaHandshake.java
+++ b/src/main/java/com/sleepycat/je/rep/stream/FeederReplicaHandshake.java
@@ -611,7 +611,7 @@ public class FeederReplicaHandshake {
          * issue a shutdown to the feeder explicitly.
          */
         if (dup != null && dup.getChannel() != null &&
-            !dup.getChannel().isOpen() && !dup.isShutdown()) {
+                !dup.isChannelAvailable()) {
             dup.shutdown(new IOException("Feeder's channel for node " +
                                          replicaNameIdPair +
                                          " is already closed"));


### PR DESCRIPTION
When master is Full GC, the observer may meet a handshake error:
```
Caused by: com.sleepycat.je.EnvironmentFailureException: Environment invalid because of previous exception: (JE 18.3.12) fe_46759e47_2b8e_47ec_87b2_6b783c807d65(-1):/data/cdw/doris/fe/meta/bdb A replica with the name: fe_46759e47_2b8e_47ec_87b2_6b783c807d65(-1) is already active with the Feeder:null HANDSHAKE_ERROR: Error during the handshake between two nodes. Some validity or compatibility check failed, preventing further communication between the nodes. Environment is invalid and must be closed. Originally thrown by HA thread: UNKNOWN fe_46759e47_2b8e_47ec_87b2_6b783c807d65(-1) Originally thrown by HA thread: UNKNOWN fe_46759e47_2b8e_47ec_87b2_6b783c807d65(-1)
        at com.sleepycat.je.rep.stream.ReplicaFeederHandshake.negotiateProtocol(ReplicaFeederHandshake.java:198) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.stream.ReplicaFeederHandshake.execute(ReplicaFeederHandshake.java:250) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.impl.node.Replica.initReplicaLoop(Replica.java:709) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.impl.node.Replica.runReplicaLoopInternal(Replica.java:485) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.impl.node.Replica.runReplicaLoop(Replica.java:412) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.impl.node.RepNode.run(RepNode.java:1869) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
```
I found `starrocks-bdb-je` has resolved this bug. So, I pick it to doris's bdbje.