### PR TITLE
[fix](inverted index) reject null bytes in term middle to avoid stack overflow

### DIFF
--- a/src/core/CLucene/index/SDocumentWriter.cpp
+++ b/src/core/CLucene/index/SDocumentWriter.cpp
@@ -504,6 +504,26 @@ void SDocumentsWriter<T>::ThreadState::FieldData::addPosition(Token *token) {
         code = (code * 31) + tokenText[upto++];
     uint32_t hashPos = code & postingsHashMask;
 
+    if (upto < tokenTextLen) {
+        for (int32_t i = upto; i < tokenTextLen; i++) {
+            if (tokenText[i] != CLUCENE_END_OF_WORD) {
+                char error_msg[512];
+                if constexpr (std::is_same_v<T, char>) {
+                    snprintf(error_msg, sizeof(error_msg),
+                             "Inverted index does not support terms with null byte (\\0) in the "
+                             "middle. "
+                             "Found null at position %d, but non-null character at position %d. "
+                             "Term prefix: '%.*s'.",
+                             upto, i, std::min(upto, 50), tokenText);
+                } else {
+                    snprintf(error_msg, sizeof(error_msg),
+                             "Term contains null character in the middle at position %d.", upto);
+                }
+                _CLTHROWA(CL_ERR_IllegalArgument, error_msg);
+            }
+        }
+    }
+
     assert(!postingsCompacted);
 
     // Locate Posting in hash


### PR DESCRIPTION
✅ 允许（放行）
"\0\0\0\0"         →  upto=0, all_trailing_nulls=true  →  ✅ 放行（空字符串+填充）
"hello\0\0\0"      →  upto=5, all_trailing_nulls=true  →  ✅ 放行（CHAR填充）
"abc\0\0"          →  upto=3, all_trailing_nulls=true  →  ✅ 放行（CHAR填充）

❌ 拒绝（抛异常）
"\0hello"          →  upto=0, all_trailing_nulls=false →  ❌ 拒绝（中间有内容）
"hel\0lo"          →  upto=3, all_trailing_nulls=false →  ❌ 拒绝（中间有内容）
"abc\0\0xyz"       →  upto=3, all_trailing_nulls=false →  ❌ 拒绝（中间有内容）

clucene以"\0"作为字符串结尾，当传入字符串有"\0"会导致程序异常（quick sort 死循环栈溢出），目前暂不修改让clucene支持“\0”字符串，增加异常判断在出现异常数据时抛出异常