### PR TITLE
[fix](clucene) Fix GCC -Werror=overloaded-virtual in FieldForMerge

### DIFF
--- a/src/core/CLucene/index/_FieldsReader.h
+++ b/src/core/CLucene/index/_FieldsReader.h
@@ -153,6 +153,10 @@ CL_NS_DEF(index)
 		// for merge
 		class FieldForMerge : public CL_NS(document)::Field {
 		public:
+			using CL_NS(document)::Field::stringValue;
+			using CL_NS(document)::Field::readerValue;
+			using CL_NS(document)::Field::tokenStreamValue;
+
 			const TCHAR* stringValue() const;
 			CL_NS(util)::Reader* readerValue() const;
 			const CL_NS(util)::ValueArray<uint8_t>* binaryValue();


### PR DESCRIPTION
## Summary
- Add `using` declarations in `FieldForMerge` to bring base class `Field`'s non-const virtual methods (`stringValue`, `readerValue`, `tokenStreamValue`) into scope
- This prevents GCC `-Werror=overloaded-virtual` errors when `Field.h` and `_FieldsReader.h` are included through different include chains in the same translation unit
- Verified locally with GCC 15.1.0 + Doris BE Release build

## Context
Apache Doris PR #59847 fails on Performance pipeline (GCC) because:
1. `CLucene/document/Field.h` declares `virtual tokenStreamValue()` (non-const)
2. `FieldForMerge` in `_FieldsReader.h` declares `tokenStreamValue() const` which hides the base class method
3. GCC with `-Wall -Werror` treats this as an error (`-Werror=overloaded-virtual`)