### PR TITLE
[fix] prevent macos-13 runner starvation from blocking docker image update

### DIFF
--- a/.github/workflows/build-4.0.yml
+++ b/.github/workflows/build-4.0.yml
@@ -113,32 +113,9 @@ jobs:
     needs: prerelease
     if: needs.prerelease.outputs.should_release == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_build == 'true')
     strategy:
+      fail-fast: false
       matrix:
         config:
-          - name: macOS-x86_64
-            os: macos-13
-            packages: >-
-              'm4'
-              'automake'
-              'autoconf'
-              'libtool'
-              'pkg-config'
-              'texinfo'
-              'coreutils'
-              'gnu-getopt'
-              'python@3'
-              'ninja'
-              'ccache'
-              'bison'
-              'byacc'
-              'gettext'
-              'wget'
-              'pcre'
-              'openjdk@11'
-              'maven'
-              'node'
-              'llvm@20'
-
           - name: macOS-arm64
             os: macos-14
             packages: >-
@@ -458,7 +435,7 @@ jobs:
   failure:
     name: Failure
     needs: [build, update-docker]
-    if: failure()
+    if: always() && failure()
     runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,10 +99,12 @@ jobs:
     needs: prerelease
     if: needs.prerelease.outputs.should_release == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_build == 'true')
     strategy:
+      fail-fast: false
       matrix:
         config:
           - name: macOS-x86_64
             os: macos-13
+            continue-on-error: true
             packages: >-
               'm4'
               'automake'
@@ -176,6 +178,7 @@ jobs:
               'maven'
 
     runs-on: ${{ matrix.config.os }}
+    continue-on-error: ${{ matrix.config.continue-on-error == true }}
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -422,7 +425,7 @@ jobs:
   failure:
     name: Failure
     needs: [build, update-docker]
-    if: failure()
+    if: always() && failure()
     runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Problem

The \`build\` matrix job includes \`macOS-x86_64\` running on \`macos-13\`. GitHub Actions \`macos-13\` (Intel Mac) runners have become increasingly scarce and can queue for up to **24 hours** before timing out. This caused a cascade of failures:

1. \`macos-13\` runner waits 24h → times out → entire \`build\` matrix result = \`failure\`
2. \`update-docker\` condition requires \`build.result == 'success'\` → **skipped**
3. \`success\` job depends on \`update-docker\` → **skipped**
4. \`failure\` job has \`if: failure()\` but \`update-docker\` was skipped (not failed), so \`failure\` also **does not run**
5. Release status is stuck at \`BUILDING\` indefinitely; Docker image is never updated

This was observed in run [#26616785582](https://github.com/apache/doris-thirdparty/actions/runs/26616785582) where the \`macOS-x86_64\` build waited exactly 24h0m0s.

## Fix

### \`build-4.0.yml\`
- **Remove \`macOS-x86_64\` (macos-13)** from the matrix entirely — branch-4.0 has no downstream consumers that need Intel Mac artifacts; Apple Silicon covers all active Mac use cases.
- **\`fail-fast: false\`** so a future matrix failure does not cancel other in-progress builds.
- **\`if: always() && failure()\`** on the \`failure\` job — fires even when \`update-docker\` is skipped rather than failed, preventing status from being stuck at \`BUILDING\`.

### \`build.yml\`
- **Keep \`macOS-x86_64\` but add \`continue-on-error: true\`** — master branch still ships Intel Mac artifacts when runners are available, but a timeout no longer blocks \`update-docker\`.
- **\`fail-fast: false\`** so a macOS timeout does not cancel the arm64/Linux builds.
- **\`if: always() && failure()\`** on the \`failure\` job — same as above.