### PR TITLE
Fix macOS x86 runner label

### DIFF
--- a/.github/workflows/build-1.2.yml
+++ b/.github/workflows/build-1.2.yml
@@ -102,7 +102,7 @@ jobs:
       matrix:
         config:
           - name: macOS-x86_64
-            os: macos-13
+            os: macos-15-intel
             packages: >-
               'm4'
               'automake'

--- a/.github/workflows/build-2.0.yml
+++ b/.github/workflows/build-2.0.yml
@@ -102,7 +102,7 @@ jobs:
       matrix:
         config:
           - name: macOS-x86_64
-            os: macos-13
+            os: macos-15-intel
             packages: >-
               'm4'
               'automake'

--- a/.github/workflows/build-2.1.yml
+++ b/.github/workflows/build-2.1.yml
@@ -102,7 +102,7 @@ jobs:
       matrix:
         config:
           - name: macOS-x86_64
-            os: macos-13
+            os: macos-15-intel
             packages: >-
               'm4'
               'automake'

--- a/.github/workflows/build-3.0.yml
+++ b/.github/workflows/build-3.0.yml
@@ -102,7 +102,7 @@ jobs:
       matrix:
         config:
           - name: macOS-x86_64
-            os: macos-13
+            os: macos-15-intel
             packages: >-
               'm4'
               'automake'

--- a/.github/workflows/build-3.1.yml
+++ b/.github/workflows/build-3.1.yml
@@ -102,7 +102,7 @@ jobs:
       matrix:
         config:
           - name: macOS-x86_64
-            os: macos-13
+            os: macos-15-intel
             packages: >-
               'm4'
               'automake'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
       matrix:
         config:
           - name: macOS-x86_64
-            os: macos-13
+            os: macos-15-intel
             continue-on-error: true
             packages: >-
               'm4'

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         config:
           - name: macOS-x86_64
-            os: macos-13
+            os: macos-15-intel
             packages: >-
               'm4'
               'automake'


### PR DESCRIPTION
## Summary
- replace deprecated macos-13 runner labels with macos-15-intel for macOS x86_64 workflow jobs
- update scheduled, manual, and branch-specific build workflows so Docker image updates are not blocked by a queued macOS x86 job

## Verification
- parsed all updated workflow YAML files with Ruby YAML loader