### PR TITLE
[fix] Add ORC filter row context

### DIFF
--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -385,11 +385,17 @@ namespace orc {
     bool getUseTightNumericVector() const;
   };
 
+  struct ORCFilterContext {
+    uint64_t batchFirstRow;
+    uint64_t stripe;
+    uint64_t rowInStripe;
+  };
+
   class ORCFilter {
    public:
     virtual ~ORCFilter() = default;
     virtual void filter(ColumnVectorBatch& data, uint16_t* sel, uint16_t size,
-                        void* arg = nullptr) const = 0;
+                        const ORCFilterContext& context, void* arg = nullptr) const = 0;
   };
 
   class StringDictFilter {

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1480,7 +1480,10 @@ namespace orc {
       // Apply filter callback to reduce number of # rows selected for decoding in the next
       // TreeReaders
       if (readerContext->getFilterCallback()) {
-        readerContext->getFilterCallback()->filter(data, sel_rowid_idx, batchSize, arg);
+        ORCFilterContext filterContext{firstRowOfStripe[currentStripe] + currentRowInStripe,
+                                       currentStripe, currentRowInStripe};
+        readerContext->getFilterCallback()->filter(data, sel_rowid_idx, batchSize, filterContext,
+                                                   arg);
       }
     }
   }


### PR DESCRIPTION
This exposes the actual ORC batch row context to filter callbacks so Doris can mark lazy-read condition cache rows with file-local row positions after SARG skips row groups.\n\nRelated Doris PR: apache/doris#65183