### PR TITLE
[fix](clucene) Support block WAND in composite readers

### DIFF
--- a/src/core/CLucene/index/MultiSegmentReader.cpp
+++ b/src/core/CLucene/index/MultiSegmentReader.cpp
@@ -757,6 +757,33 @@ bool MultiTermDocs::readRange(DocRange* docRange) {
 	}
 }
 
+bool MultiTermDocs::readBlock(DocRange* docRange) {
+	while (true) {
+		while (current == NULL) {
+			if (pointer < subReaders->length) {
+				base = starts[pointer];
+				current = termDocs(pointer++);
+			} else {
+				return false;
+			}
+		}
+		if (!current->readBlock(docRange)) {
+			current = nullptr;
+		} else {
+			if (docRange->doc_many && docRange->doc_many_size_ > 0) {
+				auto begin = docRange->doc_many->begin();
+				auto end = docRange->doc_many->begin() + docRange->doc_many_size_;
+				std::transform(begin, end, begin, [this](int32_t val) { return val + base; });
+			}
+			if (docRange->type_ == DocRangeType::kRange) {
+				docRange->doc_range.first += base;
+				docRange->doc_range.second += base;
+			}
+			return true;
+		}
+	}
+}
+
 bool MultiTermDocs::skipTo(const int32_t target) {
 //	do {
 //	  if (!next())
@@ -773,6 +800,50 @@ bool MultiTermDocs::skipTo(const int32_t target) {
 			return false;
 		}
 	}
+}
+
+bool MultiTermDocs::skipToBlock(const int32_t target) {
+	while (true) {
+		while (current == NULL) {
+			if (pointer < subReaders->length) {
+				base = starts[pointer];
+				current = termDocs(pointer++);
+			} else {
+				return true;
+			}
+		}
+
+		if (target >= starts[pointer]) {
+			current = nullptr;
+			continue;
+		}
+
+		return current->skipToBlock(target - base);
+	}
+}
+
+int32_t MultiTermDocs::getMaxBlockFreq() {
+	return current != NULL ? current->getMaxBlockFreq() : -1;
+}
+
+int32_t MultiTermDocs::getMaxBlockNorm() {
+	return current != NULL ? current->getMaxBlockNorm() : -1;
+}
+
+int32_t MultiTermDocs::getLastDocInBlock() {
+	if (current == NULL) {
+		return LUCENE_INT32_MAX_SHOULDBE;
+	}
+
+	int32_t lastDoc = current->getLastDocInBlock();
+	if (lastDoc == -1) {
+		return -1;
+	}
+	if (lastDoc == LUCENE_INT32_MAX_SHOULDBE) {
+		return pointer < subReaders->length ? starts[pointer] - 1
+		                                    : LUCENE_INT32_MAX_SHOULDBE;
+	}
+	return base + lastDoc;
 }
 
 void MultiTermDocs::close() {

--- a/src/core/CLucene/index/_MultiSegmentReader.h
+++ b/src/core/CLucene/index/_MultiSegmentReader.h
@@ -173,9 +173,15 @@ public:
   int32_t read(int32_t* docs, int32_t* freqs, int32_t length);
   int32_t read(int32_t* docs, int32_t* freqs, int32_t* norms , int32_t length);
   bool readRange(DocRange* docRange) override;
+  bool readBlock(DocRange* docRange) override;
 
    /* A Possible future optimization could skip entire segments */
   bool skipTo(const int32_t target);
+  bool skipToBlock(const int32_t target) override;
+
+  int32_t getMaxBlockFreq() override;
+  int32_t getMaxBlockNorm() override;
+  int32_t getLastDocInBlock() override;
 
 
   void close();


### PR DESCRIPTION
### What problem does this PR solve?

MultiReader and MultiSegmentReader both expose postings through MultiTermDocs. query_v2 WAND uses the block postings API, but MultiTermDocs did not implement it, so composite CLucene readers could not participate in block WAND.

Implement block reads, block skips, and block metadata forwarding while translating leaf-local document IDs to composite-reader coordinates.

### Release note

None

### Check List

- Test: BE unit test
  - `./run-be-ut.sh --run --filter=MultiSegmentCollectorTest.BlockWand* -j 16`