### PR TITLE
[fix](clucene) Support block WAND in composite readers

### DIFF
--- a/src/core/CLucene/index/MultiSegmentReader.cpp
+++ b/src/core/CLucene/index/MultiSegmentReader.cpp
@@ -757,6 +757,33 @@ bool MultiTermDocs::readRange(DocRange* docRange) {
 	}
 }
 
+bool MultiTermDocs::readBlock(DocRange* docRange) {
+	while (true) {
+		while (current == NULL) {
+			if (pointer < subReaders->length) {
+				base = starts[pointer];
+				current = termDocs(pointer++);
+			} else {
+				return false;
+			}
+		}
+		if (!current->readBlock(docRange)) {
+			current = nullptr;
+		} else {
+			if (docRange->doc_many && docRange->doc_many_size_ > 0) {
+				auto begin = docRange->doc_many->begin();
+				auto end = docRange->doc_many->begin() + docRange->doc_many_size_;
+				std::transform(begin, end, begin, [this](int32_t val) { return val + base; });
+			}
+			if (docRange->type_ == DocRangeType::kRange) {
+				docRange->doc_range.first += base;
+				docRange->doc_range.second += base;
+			}
+			return true;
+		}
+	}
+}
+
 bool MultiTermDocs::skipTo(const int32_t target) {
 //	do {
 //	  if (!next())
@@ -773,6 +800,54 @@ bool MultiTermDocs::skipTo(const int32_t target) {
 			return false;
 		}
 	}
+}
+
+bool MultiTermDocs::skipToBlock(const int32_t target) {
+	bool switched_reader = false;
+	while (true) {
+		while (current == NULL) {
+			if (pointer < subReaders->length) {
+				base = starts[pointer];
+				current = termDocs(pointer++);
+			} else {
+				return true;
+			}
+		}
+
+		if (target >= starts[pointer]) {
+			current = nullptr;
+			switched_reader = true;
+			continue;
+		}
+
+		// A child without a skip list returns false even though switching readers
+		// invalidates the caller's cached block metadata.
+		return switched_reader || current->skipToBlock(target - base);
+	}
+}
+
+int32_t MultiTermDocs::getMaxBlockFreq() {
+	return current != NULL ? current->getMaxBlockFreq() : -1;
+}
+
+int32_t MultiTermDocs::getMaxBlockNorm() {
+	return current != NULL ? current->getMaxBlockNorm() : -1;
+}
+
+int32_t MultiTermDocs::getLastDocInBlock() {
+	if (current == NULL) {
+		return LUCENE_INT32_MAX_SHOULDBE;
+	}
+
+	int32_t lastDoc = current->getLastDocInBlock();
+	if (lastDoc == -1) {
+		return -1;
+	}
+	if (lastDoc == LUCENE_INT32_MAX_SHOULDBE) {
+		return pointer < subReaders->length ? starts[pointer] - 1
+		                                    : LUCENE_INT32_MAX_SHOULDBE;
+	}
+	return base + lastDoc;
 }
 
 void MultiTermDocs::close() {

--- a/src/core/CLucene/index/SegmentTermDocs.cpp
+++ b/src/core/CLucene/index/SegmentTermDocs.cpp
@@ -307,7 +307,8 @@ bool SegmentTermDocs::skipToBlock(const int32_t target) {
         freqStream->seek(skipListReader->getFreqPointer());
         skipProx(skipListReader->getProxPointer(), skipListReader->getPayloadLength());
         _doc = skipListReader->getDoc();
-        count = newCount;
+        // -1 means the target is in the first skip block and no postings were skipped.
+        count = newCount < 0 ? 0 : newCount;
         return true;
     }
     return false;

--- a/src/core/CLucene/index/_MultiSegmentReader.h
+++ b/src/core/CLucene/index/_MultiSegmentReader.h
@@ -173,9 +173,15 @@ public:
   int32_t read(int32_t* docs, int32_t* freqs, int32_t length);
   int32_t read(int32_t* docs, int32_t* freqs, int32_t* norms , int32_t length);
   bool readRange(DocRange* docRange) override;
+  bool readBlock(DocRange* docRange) override;
 
    /* A Possible future optimization could skip entire segments */
   bool skipTo(const int32_t target);
+  bool skipToBlock(const int32_t target) override;
+
+  int32_t getMaxBlockFreq() override;
+  int32_t getMaxBlockNorm() override;
+  int32_t getLastDocInBlock() override;
 
 
   void close();

--- a/src/test/index/TestReadRange.cpp
+++ b/src/test/index/TestReadRange.cpp
@@ -6,6 +6,7 @@
 #include <CLucene.h>
 #include <CLucene/index/DocRange.h>
 #include <CLucene/index/IndexReader.h>
+#include <CLucene/index/MultiReader.h>
 #include <CLucene/util/stringUtil.h>
 
 #include <algorithm>
@@ -987,6 +988,279 @@ void TestBlockBasedInterfaces(CuTest* tc) {
 }
 
 //=============================================================================
+// Test: block APIs on MultiTermDocs through MultiReader
+//=============================================================================
+void TestMultiReaderBlockApis(CuTest* tc) {
+    constexpr int32_t firstReaderDocumentCount = 1149;
+    constexpr int32_t secondReaderDocumentCount = 1134;
+    const std::string fieldName = "content";
+    const std::string termText = "target";
+
+    std::vector<std::string> firstDocuments;
+    std::vector<std::string> secondDocuments;
+    firstDocuments.reserve(firstReaderDocumentCount);
+    secondDocuments.reserve(secondReaderDocumentCount);
+    for (int32_t i = 0; i < firstReaderDocumentCount; ++i) {
+        firstDocuments.emplace_back(termText + " " + termText);
+    }
+    for (int32_t i = 0; i < secondReaderDocumentCount; ++i) {
+        secondDocuments.emplace_back(termText + " " + termText + " " + termText);
+    }
+
+    RAMDirectory firstDirectory;
+    RAMDirectory secondDirectory;
+    writeTestIndex(fieldName, &firstDirectory, IndexVersion::kV4, firstDocuments);
+    writeTestIndex(fieldName, &secondDirectory, IndexVersion::kV4, secondDocuments);
+
+    ValueArray<IndexReader*> readers(2);
+    readers[0] = IndexReader::open(&firstDirectory);
+    readers[1] = IndexReader::open(&secondDirectory);
+    auto* reader = _CLNEW MultiReader(&readers, true);
+    std::exception_ptr eptr;
+    Term* term = nullptr;
+
+    try {
+        std::wstring fieldNameW = StringUtil::string_to_wstring(fieldName);
+        std::wstring termTextW = StringUtil::string_to_wstring(termText);
+        term = _CLNEW Term(fieldNameW.c_str(), termTextW.c_str());
+
+        TermDocs* nextDocs = reader->termDocs();
+        nextDocs->seek(term);
+        TermDocsResult expected = readWithNext(nextDocs);
+        nextDocs->close();
+        _CLDELETE(nextDocs);
+
+        TermDocs* blockDocs = reader->termDocs();
+        blockDocs->seek(term);
+        TermDocsResult actual;
+        DocRange docRange;
+        bool sawSecondReader = false;
+        bool sawBlockMetadata = false;
+        bool sawSecondReaderBlockBoundary = false;
+        bool blockDocsAreOrdered = true;
+        bool blockMetadataIsValid = true;
+        int32_t previousDoc = -1;
+        std::vector<uint32_t> blockSizes;
+        while (blockDocs->readBlock(&docRange)) {
+            blockDocsAreOrdered = blockDocsAreOrdered && docRange.doc_many_size_ > 0;
+            blockSizes.push_back(docRange.doc_many_size_);
+
+            int32_t actualMaxFreq = 0;
+            for (uint32_t i = 0; i < docRange.doc_many_size_; ++i) {
+                int32_t doc = (*docRange.doc_many)[i];
+                int32_t freq = (*docRange.freq_many)[i];
+                blockDocsAreOrdered = blockDocsAreOrdered && doc > previousDoc;
+                previousDoc = doc;
+                actual.docs.push_back(doc);
+                actual.freqs.push_back(freq);
+                actualMaxFreq = std::max(actualMaxFreq, freq);
+                sawSecondReader = sawSecondReader || doc >= firstReaderDocumentCount;
+            }
+
+            int32_t maxBlockFreq = blockDocs->getMaxBlockFreq();
+            int32_t maxBlockNorm = blockDocs->getMaxBlockNorm();
+            int32_t lastDocInBlock = blockDocs->getLastDocInBlock();
+            if (maxBlockFreq >= 0 && maxBlockNorm >= 0) {
+                sawBlockMetadata = true;
+                blockMetadataIsValid = blockMetadataIsValid && maxBlockFreq >= actualMaxFreq;
+            }
+            if (lastDocInBlock >= 0) {
+                const int32_t lastDocInRange =
+                        (*docRange.doc_many)[docRange.doc_many_size_ - 1];
+                blockMetadataIsValid =
+                        blockMetadataIsValid &&
+                        lastDocInBlock >= lastDocInRange;
+                sawSecondReaderBlockBoundary = sawSecondReaderBlockBoundary ||
+                                               (*docRange.doc_many)[0] >= firstReaderDocumentCount;
+            }
+        }
+        blockDocs->close();
+        _CLDELETE(blockDocs);
+
+        assertTrueMsg(_T("all composite block docs must match next()"),
+                      compareTermDocsResults(expected, actual));
+        assertTrueMsg(_T("composite block docs must remain ordered"), blockDocsAreOrdered);
+        assertTrueMsg(_T("composite block read must reach the second reader"), sawSecondReader);
+        assertTrueMsg(_T("composite block metadata must be available"), sawBlockMetadata);
+        assertTrueMsg(_T("composite block metadata must cross the reader boundary"),
+                      sawSecondReaderBlockBoundary);
+        assertTrueMsg(_T("block metadata must cover the returned physical block"),
+                      blockMetadataIsValid);
+
+        const std::vector<uint32_t> expectedBlockSizes = {511, 512, 126, 511, 512, 111};
+        assertTrueMsg(_T("composite reader must preserve short physical tail blocks"),
+                      blockSizes == expectedBlockSizes);
+
+        for (int32_t target : {1023, firstReaderDocumentCount - 1, firstReaderDocumentCount,
+                               firstReaderDocumentCount + 37}) {
+            TermDocs* skippedDocs = reader->termDocs();
+            skippedDocs->seek(term);
+            skippedDocs->skipToBlock(target);
+
+            std::vector<int32_t> actualTail;
+            DocRange skippedRange;
+            while (skippedDocs->readBlock(&skippedRange)) {
+                for (uint32_t i = 0; i < skippedRange.doc_many_size_; ++i) {
+                    int32_t doc = (*skippedRange.doc_many)[i];
+                    if (target >= firstReaderDocumentCount) {
+                        assertTrue(doc >= firstReaderDocumentCount);
+                    }
+                    if (doc >= target) {
+                        actualTail.push_back(doc);
+                    }
+                }
+            }
+            skippedDocs->close();
+            _CLDELETE(skippedDocs);
+
+            std::vector<int32_t> expectedTail;
+            for (int32_t doc : expected.docs) {
+                if (doc >= target) {
+                    expectedTail.push_back(doc);
+                }
+            }
+            assertTrue(actualTail == expectedTail);
+        }
+    } catch (...) {
+        eptr = std::current_exception();
+    }
+
+    FINALLY(eptr, {
+        _CLDECDELETE(term);
+        reader->close();
+        _CLDELETE(reader);
+    })
+
+    std::cout << "\nTestMultiReaderBlockApis success" << std::endl;
+}
+
+//=============================================================================
+// Test: changing child readers invalidates block state even when the new child
+// has fewer postings than a skip block.
+//=============================================================================
+void TestMultiReaderBlockSkipAcrossShortReaders(CuTest* tc) {
+    constexpr int32_t firstReaderDocumentCount = 128;
+    constexpr int32_t secondReaderDocumentCount = 11;
+    const std::string fieldName = "content";
+    const std::string termText = "target";
+
+    std::vector<std::string> firstDocuments(firstReaderDocumentCount, termText);
+    std::vector<std::string> secondDocuments(secondReaderDocumentCount, termText);
+    RAMDirectory firstDirectory;
+    RAMDirectory secondDirectory;
+    writeTestIndex(fieldName, &firstDirectory, IndexVersion::kV4, firstDocuments);
+    writeTestIndex(fieldName, &secondDirectory, IndexVersion::kV4, secondDocuments);
+
+    ValueArray<IndexReader*> readers(2);
+    readers[0] = IndexReader::open(&firstDirectory);
+    readers[1] = IndexReader::open(&secondDirectory);
+    auto* reader = _CLNEW MultiReader(&readers, true);
+    std::exception_ptr eptr;
+    Term* term = nullptr;
+
+    try {
+        std::wstring fieldNameW = StringUtil::string_to_wstring(fieldName);
+        std::wstring termTextW = StringUtil::string_to_wstring(termText);
+        term = _CLNEW Term(fieldNameW.c_str(), termTextW.c_str());
+
+        TermDocs* termDocs = reader->termDocs();
+        termDocs->seek(term);
+
+        DocRange firstRange;
+        assertTrue(termDocs->readBlock(&firstRange));
+        assertEquals(firstReaderDocumentCount, firstRange.doc_many_size_);
+        assertTrue(!termDocs->skipToBlock(firstReaderDocumentCount - 1));
+
+        // The second child has no skip list, so only MultiTermDocs can report
+        // the state transition that invalidates a WAND block cache.
+        assertTrue(termDocs->skipToBlock(firstReaderDocumentCount));
+
+        DocRange secondRange;
+        assertTrue(termDocs->readBlock(&secondRange));
+        assertEquals(secondReaderDocumentCount, secondRange.doc_many_size_);
+        for (uint32_t i = 0; i < secondRange.doc_many_size_; ++i) {
+            assertEquals(firstReaderDocumentCount + static_cast<int32_t>(i),
+                         (*secondRange.doc_many)[i]);
+        }
+        assertTrue(!termDocs->readBlock(&secondRange));
+
+        termDocs->close();
+        _CLDELETE(termDocs);
+    } catch (...) {
+        eptr = std::current_exception();
+    }
+
+    FINALLY(eptr, {
+        _CLDECDELETE(term);
+        reader->close();
+        _CLDELETE(reader);
+    })
+
+    std::cout << "\nTestMultiReaderBlockSkipAcrossShortReaders success" << std::endl;
+}
+
+//=============================================================================
+// Test: after skipping a block in a large child, entering a short child still
+// reports the reader transition to a block-WAND caller.
+//=============================================================================
+void TestMultiReaderBlockSkipIntoShortReader(CuTest* tc) {
+    constexpr int32_t firstReaderDocumentCount = 1149;
+    constexpr int32_t secondReaderDocumentCount = 11;
+    const std::string fieldName = "content";
+    const std::string termText = "target";
+
+    std::vector<std::string> firstDocuments(firstReaderDocumentCount, termText);
+    std::vector<std::string> secondDocuments(secondReaderDocumentCount, termText);
+    RAMDirectory firstDirectory;
+    RAMDirectory secondDirectory;
+    writeTestIndex(fieldName, &firstDirectory, IndexVersion::kV4, firstDocuments);
+    writeTestIndex(fieldName, &secondDirectory, IndexVersion::kV4, secondDocuments);
+
+    ValueArray<IndexReader*> readers(2);
+    readers[0] = IndexReader::open(&firstDirectory);
+    readers[1] = IndexReader::open(&secondDirectory);
+    auto* reader = _CLNEW MultiReader(&readers, true);
+    std::exception_ptr eptr;
+    Term* term = nullptr;
+
+    try {
+        std::wstring fieldNameW = StringUtil::string_to_wstring(fieldName);
+        std::wstring termTextW = StringUtil::string_to_wstring(termText);
+        term = _CLNEW Term(fieldNameW.c_str(), termTextW.c_str());
+
+        TermDocs* termDocs = reader->termDocs();
+        termDocs->seek(term);
+
+        // This skip enters the first reader's final short physical block.
+        assertTrue(termDocs->skipToBlock(1023));
+        // This one changes readers; the new reader has df < skipInterval.
+        assertTrue(termDocs->skipToBlock(firstReaderDocumentCount));
+
+        DocRange shortReaderRange;
+        assertTrue(termDocs->readBlock(&shortReaderRange));
+        assertEquals(secondReaderDocumentCount, shortReaderRange.doc_many_size_);
+        for (uint32_t i = 0; i < shortReaderRange.doc_many_size_; ++i) {
+            assertEquals(firstReaderDocumentCount + static_cast<int32_t>(i),
+                         (*shortReaderRange.doc_many)[i]);
+        }
+        assertTrue(!termDocs->readBlock(&shortReaderRange));
+
+        termDocs->close();
+        _CLDELETE(termDocs);
+    } catch (...) {
+        eptr = std::current_exception();
+    }
+
+    FINALLY(eptr, {
+        _CLDECDELETE(term);
+        reader->close();
+        _CLDELETE(reader);
+    })
+
+    std::cout << "\nTestMultiReaderBlockSkipIntoShortReader success" << std::endl;
+}
+
+//=============================================================================
 // Suite registration
 //=============================================================================
 CuSuite* testReadRange() {
@@ -1000,6 +1274,9 @@ CuSuite* testReadRange() {
     SUITE_ADD_TEST(suite, TestReadRangeVersions);
     SUITE_ADD_TEST(suite, TestReadRangeEdgeCases);
     SUITE_ADD_TEST(suite, TestBlockBasedInterfaces);
+    SUITE_ADD_TEST(suite, TestMultiReaderBlockApis);
+    SUITE_ADD_TEST(suite, TestMultiReaderBlockSkipAcrossShortReaders);
+    SUITE_ADD_TEST(suite, TestMultiReaderBlockSkipIntoShortReader);
 
     return suite;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62955

Related PR: None

Problem Summary:

The `fix/multi-reader-block-wand` branch adds block-WAND support for composite
readers (`MultiReader` / `MultiTermDocs`). The block APIs previously worked only
for a segment reader, so a caller using a composite reader could not read block
postings or use block-level statistics.

This change:

- Implements `readBlock`, `skipToBlock`, `getMaxBlockFreq`, `getMaxBlockNorm`,
  and `getLastDocInBlock` in `MultiTermDocs`.
- Converts child-reader-local doc IDs and block boundaries into global doc IDs,
  while preserving each physical block, including a short tail block, rather
  than merging blocks across child-reader boundaries.
- Reports a reader transition from `skipToBlock` even when the destination
  child has fewer postings than the skip interval and therefore cannot perform
  a local skip. This invalidates the block-WAND caller's cached block metadata.
- Fixes the `SegmentTermDocs::skipToBlock` posting count after a skip-list
  lookup in the first physical block:

  ```cpp
  count = newCount < 0 ? 0 : newCount;
  ```

  `DefaultSkipListReader::skipTo()` returns `-1` when no skip entry precedes
  the target, which means the target is in the first physical block and the
  frequency stream is positioned at its beginning. At that point no posting
  has been consumed, so `count` must be `0`, not `-1`.

  For example, consider 1,149 postings stored as blocks of 511, 512, and 126
  postings. A `skipToBlock()` target in the first block returns `newCount ==
  -1`. If `count` remains `-1`, the subsequent block reads make it 510, 1,022,
  and 1,148, respectively. The reader then believes one posting remains after
  the 126-posting tail and tries to read beyond the physical postings. Starting
  from `count = 0` instead yields 511, 1,023, and 1,149, so iteration stops at
  the correct boundary.

Regression coverage in `TestReadRange.cpp` verifies:

- Composite `readBlock()` output, global doc IDs, and block metadata against
  `next()` for two readers with 1,149 and 1,134 documents, including expected
  511/512/tail physical block layouts.
- `skipToBlock()` before and across reader boundaries, including a target in a
  short tail block.
- Reader transitions into a child with only 11 postings, both from a short
  first reader and after a block skip in a larger first reader.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test: `be/ut_build_ASAN/bin/cl_test testReadRange`
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. Composite readers now expose block-WAND APIs and report
      cross-reader block state transitions.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
