### PR TITLE
Pin Rust 1.91 for thirdparty builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,11 @@ jobs:
 
       - name: Prepare for ${{ matrix.config.os }}
         run: |
+          # Doris's lance-c build prefers Rust 1.91.0 when it is installed.
+          # Pin it here so hosted-runner toolchain updates do not break locked Rust dependencies.
+          rustup toolchain install 1.91.0 --profile minimal
+          rustup run 1.91.0 rustc --version
+
           if [[ "${{ matrix.config.name }}" =~ macOS-* ]]; then
             # Install packages except cmake
             brew install ${{ matrix.config.packages }} || true

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -183,6 +183,11 @@ jobs:
 
       - name: Prepare for ${{ matrix.config.os }}
         run: |
+          # Doris's lance-c build prefers Rust 1.91.0 when it is installed.
+          # Pin it here so hosted-runner toolchain updates do not break locked Rust dependencies.
+          rustup toolchain install 1.91.0 --profile minimal
+          rustup run 1.91.0 rustc --version
+
           if [[ "${{ matrix.config.name }}" =~ macOS-* ]]; then
             # Install packages except cmake
             brew install ${{ matrix.config.packages }} || true


### PR DESCRIPTION
## What changed

- Install Rust 1.91.0 in the scheduled thirdparty build workflow.
- Apply the same toolchain pin to the manual build workflow.
- Print the pinned compiler version during environment preparation.

## Why

The hosted Ubuntu runner has moved to Rust 1.97.0. The current `lance-c v0.1.2` lockfile pins `ethnum v1.5.2`, which assumes `TryFromIntError` is zero-sized. That assumption no longer holds on Rust 1.97.0, so the build fails with `E0512` while compiling `ethnum`.

The Doris thirdparty build already prefers Rust 1.91.0 when that toolchain is installed. Installing the expected version in the workflow makes the build deterministic and avoids changing the upstream `lance-c` source archive or its lockfile.

Failed job: https://github.com/apache/doris-thirdparty/actions/runs/29551593405/job/87795875361

## Validation

- `actionlint` passes for both changed workflows.
- `ethnum v1.5.2` reproduces `E0512` with Rust 1.97.0.
- The same crate compiles successfully with Rust 1.91.0.
- `git diff --check` passes.
