### PR TITLE
[ci] Build Linux ARM64 thirdparty in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
       contents: write
     outputs:
       should_release: ${{ steps.check_diff.outputs.should_release }}
+      thirdparty_commit_hash: ${{ steps.check_diff.outputs.thirdparty_commit_hash }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,9 +55,11 @@ jobs:
           fi
           last_version="$(gh release view automation | sed -n -E 's/Doris Version: \*(.*)\*.*/\1/p')"
           current_version="$(git log -1 --format='%H')"
+          thirdparty_commit_hash="$(git log -1 --format='%H' -- thirdparty)"
 
           echo "Last Version: ${last_version}"
           echo "Current Version: ${current_version}"
+          echo "Thirdparty Commit: ${thirdparty_commit_hash}"
 
           should_release=false
           if [[ -z "${last_version}" ]]; then
@@ -83,6 +86,7 @@ jobs:
           gh release edit -F release_note.md automation
 
           echo "should_release=${should_release}" >> $GITHUB_OUTPUT
+          echo "thirdparty_commit_hash=${thirdparty_commit_hash}" >> $GITHUB_OUTPUT
 
       - name: Download Source and Upload
         if: steps.check_diff.outputs.should_release == 'true'
@@ -286,6 +290,13 @@ jobs:
           export CUSTOM_CMAKE="/usr/local/bin/cmake"
           cd thirdparty
           ./build-thirdparty.sh -j "$(nproc)"
+
+          thirdparty_commit_hash="${{ needs.prerelease.outputs.thirdparty_commit_hash }}"
+          if [[ -z "${thirdparty_commit_hash}" ]]; then
+            echo 'Thirdparty commit hash is empty' >&2
+            exit 1
+          fi
+          echo "${thirdparty_commit_hash}" >installed/_doris_thirdparty_commit_
 
           kernel="$(uname -s | awk '{print tolower($0)}')"
           arch="$(uname -m)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,34 @@ jobs:
 
           - name: Linux
             os: ubuntu-22.04
+            toolchain: ldb_toolchain_gen.sh
+            packages: >-
+              'build-essential'
+              'automake'
+              'autoconf'
+              'libtool-bin'
+              'pkg-config'
+              'cmake=3.22.1-1ubuntu1.22.04.2'
+              'ninja-build'
+              'ccache'
+              'python-is-python3'
+              'bison'
+              'byacc'
+              'flex'
+              'binutils-dev'
+              'libiberty-dev'
+              'curl'
+              'git'
+              'zip'
+              'unzip'
+              'autopoint'
+              'openjdk-8-jdk'
+              'openjdk-8-jdk-headless'
+              'maven'
+
+          - name: Linux-arm64
+            os: ubuntu-22.04-arm
+            toolchain: ldb_toolchain_gen_aarch64.sh
             packages: >-
               'build-essential'
               'automake'
@@ -237,14 +265,14 @@ jobs:
             sudo DEBIAN_FRONTEND=noninteractive apt install --yes ${{ matrix.config.packages }}
 
             mkdir -p "${DEFAULT_DIR}"
-            wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.25/ldb_toolchain_gen.sh \
+            wget "https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.25/${{ matrix.config.toolchain }}" \
               -q -O /tmp/ldb_toolchain_gen.sh
             bash /tmp/ldb_toolchain_gen.sh "${DEFAULT_DIR}/ldb-toolchain"
           fi
 
       - name: Build and Upload
         run: |
-          if [[ "${{ matrix.config.name }}" == 'Linux' ]]; then
+          if [[ "${{ matrix.config.name }}" == Linux* ]]; then
             export DEFAULT_DIR='/opt/doris'
             export PATH="${DEFAULT_DIR}/ldb-toolchain/bin:${PATH}"
             export PATH="$(find /usr/lib/jvm/java-8-openjdk* -maxdepth 1 -type d -name 'bin'):${PATH}"
@@ -261,9 +289,17 @@ jobs:
 
           kernel="$(uname -s | awk '{print tolower($0)}')"
           arch="$(uname -m)"
-          rm -rf "doris-thirdparty-prebuilt-${kernel}-${arch}.tar.xz"
-          tar -cf - installed | xz -z -T0 - >"doris-thirdparty-prebuilt-${kernel}-${arch}.tar.xz"
-          gh release upload --clobber automation "doris-thirdparty-prebuilt-${kernel}-${arch}.tar.xz"
+          archive="doris-thirdparty-prebuilt-${kernel}-${arch}.tar.xz"
+          rm -f "${archive}"
+          tar -cf - installed | xz -z -T0 - >"${archive}"
+
+          assets=("${archive}")
+          if [[ "${kernel}" == 'linux' && "${arch}" == 'aarch64' ]]; then
+            # Preserve the existing Linux ARM64 URL used by Doris release jobs.
+            cp "${archive}" doris-thirdparty-prebuild-arm64.tar.xz
+            assets+=(doris-thirdparty-prebuild-arm64.tar.xz)
+          fi
+          gh release upload --clobber automation "${assets[@]}"
 
   update-docker:
     name: Update Docker Image


### PR DESCRIPTION
## What changed

- add a native Linux ARM64 matrix entry using GitHub's `ubuntu-22.04-arm` hosted runner
- select `ldb_toolchain_gen_aarch64.sh` for the ARM64 job while keeping the existing x86_64 toolchain
- upload both `doris-thirdparty-prebuilt-linux-aarch64.tar.xz` and the existing compatibility asset `doris-thirdparty-prebuild-arm64.tar.xz`

## Why

Linux ARM64 prebuilds currently depend on an internal ARM machine plus an hourly upload cron, unlike the other three platforms. Public repositories can now use standard native ARM64 GitHub-hosted runners, so the build and publication can live in the same workflow as Linux x86_64 and macOS.

Keeping the legacy asset name avoids breaking existing Doris release jobs and download URLs during the migration.

## Validation

- `actionlint .github/workflows/build.yml`
- YAML parse and `git diff --check`
- live Linux ARM64 GitHub Actions run will be linked in a follow-up PR comment
