### PR TITLE
Fix macOS thirdparty builds and Docker release gating

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,7 @@ jobs:
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CMAKE_VERSION: 3.25.3
     steps:
       - name: Checkout easimon/maximize-build-space
         if: ${{ matrix.config.name == 'Linux' }}
@@ -254,11 +255,11 @@ jobs:
           if [[ "${{ matrix.config.name }}" =~ macOS-* ]]; then
             # Install packages except cmake
             brew install ${{ matrix.config.packages }} || true
-            # Install specific version of cmake
+            # Arrow 24 requires CMake 3.25 or newer.
             brew unlink cmake || true
-            wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1-macos-universal.tar.gz
-            tar -xzf cmake-3.22.1-macos-universal.tar.gz
-            sudo cp -r cmake-3.22.1-macos-universal/CMake.app/Contents/* /usr/local/
+            wget "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-macos-universal.tar.gz"
+            tar -xzf "cmake-${CMAKE_VERSION}-macos-universal.tar.gz"
+            sudo cp -r "cmake-${CMAKE_VERSION}-macos-universal/CMake.app/Contents/"* /usr/local/
             cmake --version
           else
             export DEFAULT_DIR='/opt/doris'
@@ -315,16 +316,35 @@ jobs:
   update-docker:
     name: Update Docker Image
     needs: [prerelease, build]
+    # macOS failures must not block Docker when the current Linux x86_64 package is available.
     if: |
-      always() && (
-        (needs.prerelease.outputs.should_release == 'true' && needs.build.result == 'success') ||
-        (github.event_name == 'workflow_dispatch' && needs.build.result != 'failure')
-      )
+      always() &&
+      needs.build.result != 'cancelled' &&
+      (needs.prerelease.outputs.should_release == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Verify Linux x86_64 prebuilt provenance
+        run: |
+          expected_commit="${{ needs.prerelease.outputs.thirdparty_commit_hash }}"
+          if [[ -z "${expected_commit}" ]]; then
+            echo 'Expected thirdparty commit hash is empty' >&2
+            exit 1
+          fi
+
+          archive='doris-thirdparty-prebuilt-linux-x86_64.tar.xz'
+          gh release download automation --pattern "${archive}"
+          actual_commit="$(tar -xOf "${archive}" installed/_doris_thirdparty_commit_)"
+          if [[ "${actual_commit}" != "${expected_commit}" ]]; then
+            echo "Linux prebuilt provenance mismatch: expected ${expected_commit}, got ${actual_commit}" >&2
+            exit 1
+          fi
+
+          echo "Verified Linux prebuilt thirdparty commit: ${actual_commit}"
+          rm -f "${archive}"
+
       - name: Checkout docker/setup-buildx-action
         run: |
           rm -rf ./.github/actions/setup-buildx-action
@@ -477,5 +497,10 @@ jobs:
         run: |
           gh release download automation
 
-          echo -ne "Status: *FAILURE*\n\n## SHA256 Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
+          content="$(gh release view automation | sed -n '/Update Time:/,/Doris Version:/p')"
+          if [[ -z "${content}" ]]; then
+            echo 'Unable to preserve release provenance in the failure note' >&2
+            exit 1
+          fi
+          echo -ne "${content}\nStatus: *FAILURE*\n\n## SHA256 Checksums\n\`\`\`\n$(sha256sum *)\n\`\`\`" >release_note.md
           gh release edit --latest -F release_note.md automation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,6 +245,24 @@ jobs:
             -o doris-thirdparty-source.tgz
           tar -zxvf doris-thirdparty-source.tgz
 
+          # The gcc.gnu.org git endpoint occasionally rate-limits hosted runners and
+          # leaves this header empty in the cached source archive. Repair only an
+          # invalid copy, and verify the mirror content before replacing it.
+          tsan_header="src/tsan_interface_atomic.h"
+          expected_md5="d72679bea167d6a513d959f5abd149dc"
+          actual_md5="$(openssl dgst -md5 "${tsan_header}" | awk '{ print $NF }')"
+          if [[ "${actual_md5}" != "${expected_md5}" ]]; then
+            tsan_header_tmp="${tsan_header}.tmp"
+            trap 'rm -f "${tsan_header_tmp}"' EXIT
+            curl --fail --location --retry 3 \
+              https://raw.githubusercontent.com/gcc-mirror/gcc/releases/gcc-7/libsanitizer/include/sanitizer/tsan_interface_atomic.h \
+              --output "${tsan_header_tmp}"
+            actual_md5="$(openssl dgst -md5 "${tsan_header_tmp}" | awk '{ print $NF }')"
+            [[ "${actual_md5}" == "${expected_md5}" ]]
+            mv "${tsan_header_tmp}" "${tsan_header}"
+            trap - EXIT
+          fi
+
       - name: Prepare for ${{ matrix.config.os }}
         run: |
           # Doris's lance-c build prefers Rust 1.91.0 when it is installed.


### PR DESCRIPTION
## Summary

- bump the macOS CMake pin from 3.22.1 to 3.25.3 so Arrow 24 can configure
- repair an invalid cached `tsan_interface_atomic.h` from the GCC GitHub mirror when gcc.gnu.org rate-limits hosted runners, verifying the expected MD5 before replacement
- let Docker image publication proceed after non-cancelled matrix failures, while verifying that the Linux x86_64 prebuilt package marker matches the expected thirdparty commit
- preserve the release update time and Doris version when recording a failed build, preventing the next scheduled run from treating it as a first release

## Root cause

Scheduled run https://github.com/apache/doris-thirdparty/actions/runs/31019437034 built and uploaded both Linux packages, but both macOS jobs failed while configuring Arrow 24:

```
CMake 3.25 or higher is required. You are running version 3.22.1
```

Because `update-docker` required the aggregate matrix result to be successful, those macOS failures skipped Docker publication even though the required Linux x86_64 package was available. The failure handler also replaced the release note without retaining `Doris Version`, causing later scheduled runs to detect an empty previous version and repeat the full build.

During runtime validation, gcc.gnu.org also rate-limited GitHub hosted runners and left `tsan_interface_atomic.h` empty in the cached source archive. The fallback repairs only an invalid copy and verifies MD5 `d72679bea167d6a513d959f5abd149dc` before replacing it.

## Safety

Docker publication now fails closed unless `installed/_doris_thirdparty_commit_` in `doris-thirdparty-prebuilt-linux-x86_64.tar.xz` exactly matches the commit exported by the prerelease job. A cancelled matrix still prevents Docker publication.

## Validation

Static and package checks:

- `actionlint -shellcheck= .github/workflows/build.yml`
- `git diff --check`
- downloaded and ran the official CMake 3.25.3 macOS universal package; it contains both x86_64 and arm64 binaries
- verified package SHA256 `771548ed2abae17f3fd28dcfa572ba3fe9f970652a72c36c2e1aafdee93a234e` against Kitware's release checksum list
- exercised the prebuilt marker extraction and equality check with a local tar.xz fixture
- exercised the GCC mirror fallback from an empty header and verified MD5 `d72679bea167d6a513d959f5abd149dc`

Full runtime validation:

- fork run: https://github.com/hello-stephen/doris-thirdparty/actions/runs/31074452722
- exact PR head: `04385bd40c223d3e1b5cd4753ec95b284c5b29ed`
- Prerelease, macOS x86_64, macOS arm64, Linux x86_64, Linux arm64, Update Docker Image, and final Success jobs all completed successfully
- both macOS logs report `cmake version 3.25.3`
- Linux prebuilt provenance verified as thirdparty commit `5baf0455f1dba3e43feda73e1c0303ab0369eaf0`
- isolated test image digest: `sha256:6213c6455b08b4bda5f29922359732f3873023a68f6f4e8721d04c704e2b2c0f`
- isolated no-AVX2 test image digest: `sha256:d869af782f9bd1912c1d489db216549615df80feebd152976cf3c661721fc82e`
