### PR TITLE
Verify checksums before publishing the source bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,22 @@ jobs:
       - name: Download Source and Upload
         if: steps.check_diff.outputs.should_release == 'true'
         run: |
+          # download-thirdparty.sh turns every checksum into a no-op when md5sum is
+          # missing, and macOS ships `md5` under a different name. That is not just a
+          # lost safety net here, it actively publishes corruption: `wget -O` creates
+          # its output file before the transfer, so a failed download leaves a 0-byte
+          # stub behind, and the retry inside download_func() then accepts the stub as
+          # a valid cached archive ("Archive ... already exist"). The job stays green
+          # and uploads the stub. That is how a 0-byte src/tsan_interface_atomic.h
+          # reached this release on 2026-08-06 and broke apache/doris CI for days.
+          # Put md5sum on PATH so the script verifies what we are about to package.
+          brew install coreutils || true
+          mkdir -p "${RUNNER_TEMP}/gnu-bin"
+          ln -sf "$(brew --prefix)/bin/gmd5sum" "${RUNNER_TEMP}/gnu-bin/md5sum"
+          export PATH="${RUNNER_TEMP}/gnu-bin:${PATH}"
+          # Fail loudly now rather than silently skipping every checksum below.
+          md5sum --version >/dev/null
+
           cd thirdparty
           sed '/# unpacking thirdpart archives/,$d' download-thirdparty.sh | bash -
 


### PR DESCRIPTION
## Problem

The `prerelease` job can publish a corrupt `doris-thirdparty-source.tgz`, stay green while
doing it, and there is currently no check that would notice.

The job runs on `macos-14`, where `md5sum` does not exist. `download-thirdparty.sh` detects
that and disables verification entirely:

```bash
md5sum_bin='md5sum'
if ! command -v "${md5sum_bin}" >/dev/null 2>&1; then
    echo "Warn: md5sum is not installed"
    md5sum_bin=""
fi

md5sum_func() {
    ...
    if [[ "${md5sum_bin}" == "" ]]; then
        return 0        # every checksum in the run now passes unconditionally
    fi
```

That turns a failed download into a published artifact:

1. `wget -q URL -O file` creates its output file **before** the transfer, so a failed
   download leaves a 0-byte stub behind.
2. `download_func()` loops twice. The second pass finds a readable file, "verifies" it
   against the disabled checksum, and reports `Archive ... already exist`.
3. `STATUS=0`, the script exits 0, the step succeeds.
4. `tar -zcvf doris-thirdparty-source.tgz src` packages the stub and
   `gh release upload --clobber` publishes it.

## This already happened

Run [31092954046](https://github.com/apache/doris-thirdparty/actions/runs/31092954046),
job `Prerelease` (92588053054), 2026-08-06 — the job is green:

```
1211: Warn: md5sum is not installed
...
1308: Downloading tsan_interface_atomic.h from https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;...
1309: Failed to download tsan_interface_atomic.h. attemp: 1
1310: Archive tsan_interface_atomic.h already exist.
...
1420: a src/tsan_interface_atomic.h
```

The asset published at `2026-08-06T10:28:21Z` still carries it. Streaming the current
release asset and extracting that single member:

```
$ curl -sL https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-source.tgz \
    | tar -xzO --occurrence=1 src/tsan_interface_atomic.h | wc -c
0
```

Consequence downstream: every `apache/doris` thirdparty job now fails the md5 check on that
header (Linux does have `md5sum`) and falls back to fetching it from `gcc.gnu.org`. Runners
that cannot reach that host fail the build outright — for example
[apache/doris run 31463316509](https://github.com/apache/doris/actions/runs/31463316509),
where Linux and macOS recovered but macOS-arm64 died on
`Failed to download tsan_interface_atomic.h`. Note that `download_func()` retries twice, but
when a corrupt file is already on disk the first pass is spent detecting and removing it, so
an unreachable host gets a single attempt.

## Fix

Put `md5sum` on `PATH` for this step so the script's own verification actually runs. A failed
download then fails the job instead of shipping the stub. Only `md5sum` is linked in, so no
other GNU coreutils binary shadows a BSD one for the rest of the step.

An explicit `md5sum --version` follows the setup, so that a problem installing it fails the
job loudly rather than silently reverting to "skip every checksum".

## Verification

Ran the download stage of `download-thirdparty.sh` in an isolated directory with an
unreachable download URL, once with `md5sum` absent from `PATH` and once with it present.

Without `md5sum` — reproduces the bug exactly, note the identical two log lines:

```
Downloading tsan_interface_atomic.h from https://unreachable-a.invalid/x ...
Failed to download tsan_interface_atomic.h. attemp: 1
Archive tsan_interface_atomic.h already exist.
exit code = 0
src/tsan_interface_atomic.h -> 0 bytes, would be packaged and published
```

With `md5sum` — the stub is caught and removed, and the job would stop before `tar`:

```
Failed to download tsan_interface_atomic.h. attemp: 1
src/tsan_interface_atomic.h md5sum check failed!
except-md5 d72679bea167d6a513d959f5abd149dc
actual-md5 d41d8cd98f00b204e9800998ecf8427e
Archive tsan_interface_atomic.h will be removed and download again.
Failed to download tsan_interface_atomic.h
exit code = 1
src/ -> no leftover file
```

## Note on the currently published asset

This PR stops the job from publishing corruption; it does not repair the asset that is
already out there. The bundle is only rebuilt when `git diff` reports changes under
`thirdparty/`, so it will be regenerated on the next cron tick after any `apache/doris`
thirdparty change lands — with this PR merged, that rebuild will be verified.

Related: apache/doris#66650 adds a mirror fallback for the tsan header so that the
`gcc.gnu.org` outage stops being fatal on the consuming side.
